### PR TITLE
Improve XMPP presence handling

### DIFF
--- a/src/xmppjs/GatewayMUCMembership.ts
+++ b/src/xmppjs/GatewayMUCMembership.ts
@@ -96,6 +96,12 @@ export class GatewayMUCMembership {
         return set.delete(member);
     }
 
+    /**
+     * Remove an XMPP member from the gateway membership.
+     * @param chatName The MUC the user is part of
+     * @param realJid The real JID of the user
+     * @returns True if this is the last device for this member, false otherwise.
+     */
     public removeXmppMember(chatName: string, realJid: string): boolean {
         const member = this.getXmppMemberByRealJid(chatName, realJid);
         if (!member) {

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -165,9 +165,9 @@ export class XmppJsGateway implements IGateway {
      * @param stanza The XMPP stanza message
      * @returns If the message was sent successfully.
      */
-    public async reflectXMPPMessage(chatName: string, stanza: Element): Promise<boolean> {
+    public async reflectXMPPMessage(chatName: string, stanza: Element, kickNonMember=true): Promise<boolean> {
         const member = this.members.getXmppMemberByRealJid(chatName, stanza.attrs.from);
-        if (!member) {
+        if (!member && kickNonMember) {
             log.warn(`${stanza.attrs.from} is not part of this room.`);
             // Send the sender an error.
             const kick = new StzaPresenceKick(
@@ -413,7 +413,7 @@ export class XmppJsGateway implements IGateway {
             true,
         );
 
-        // Matrix is non-anon, and matrix logs.
+        // Matrix is non-anon, and Matrix logs.
         selfPresence.statusCodes.add(XMPPStatusCode.RoomNonAnonymous);
         selfPresence.statusCodes.add(XMPPStatusCode.RoomLoggingEnabled);
         await this.xmpp.xmppSend(selfPresence);
@@ -427,7 +427,7 @@ export class XmppJsGateway implements IGateway {
                 }, [
                     x("item", {affiliation: "member", role: "participant"}),
                 ]),
-        ));
+        ), false);
 
         // FROM THIS POINT ON, WE CONSIDER THE USER JOINED.
 

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -552,10 +552,10 @@ export class XmppJsGateway implements IGateway {
             log.error(`User tried to leave room, but they aren't in the member list`);
             return;
         }
-        this.members.removeXmppMember(chatName, stanza.attrs.from);
+        const lastDevice = this.members.removeXmppMember(chatName, stanza.attrs.from);
         const leaveStza = new StzaPresenceItem(
             user.anonymousJid.toString(),
-            stanza.attrs.to,
+            stanza.attrs.from,
             undefined,
             "member",
             "none",
@@ -564,7 +564,11 @@ export class XmppJsGateway implements IGateway {
         );
         leaveStza.presenceType = "unavailable";
         this.xmpp.xmppWriteToStream(leaveStza);
-        leaveStza.self = false;
-        this.reflectXMPPStanza(chatName, leaveStza);
+        // If this is the last device for that member, reflect
+        // that change to everyone.
+        if (lastDevice) {
+            leaveStza.self = false;
+            this.reflectXMPPStanza(chatName, leaveStza);
+        }
     }
 }

--- a/src/xmppjs/XJSInstance.ts
+++ b/src/xmppjs/XJSInstance.ts
@@ -477,7 +477,7 @@ export class XmppJsInstance extends EventEmitter implements IBifrostInstance {
                 // and set the right to/from addresses.
                 convName = `${to.local}@${to.domain}`;
                 log.info(`Sending gateway group message to ${convName}`);
-                if (!this.gateway!.reflectXMPPMessage(convName, stanza)) {
+                if (!(await this.gateway!.reflectXMPPMessage(convName, stanza))) {
                     log.warn(`Message could not be sent, not forwarding to Matrix`);
                     return;
                 }


### PR DESCRIPTION
This PR should:

- Await the presence sending of MUC membership before sending self presence to avoid confusing clients
- Only broadcast leave presence when the last device has left the MUC for a user.

Should fix #120, #93