### PR TITLE
Improve membership handling for Matrix and XMPP users

### DIFF
--- a/changelog.d/144.changelog
+++ b/changelog.d/144.changelog
@@ -1,0 +1,5 @@
+- Remove IEventRequestData in favour of WeakEvent and MatrixMembershipEvent
+- Use enums over strings for stanzas
+- Fix an issue where PostgreSQL would not work because of an old version of the library.
+- Ensure kicks propagate to XMPP
+- Add tests for the gateway membership management class.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -20,8 +20,8 @@ datastore:
   # connectionString: "nedb://."
 
 purple:
-  # For selecting a specific backend. One of "node-purple", "xmpp.js". Defaults to "node-purple"
-  backend: "xmpp.js"
+  # For selecting a specific backend. One of "node-purple", "xmpp-js". Defaults to "node-purple"
+  backend: "xmpp-js"
 # -- For xmpp.js - You need an existing xmpp server for this to work.
   backendOpts:
     # endpoint to reach the component on. The default port is 5347

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "marked": "^1.2.0",
     "matrix-appservice-bridge": "^2.1.0",
     "parse-entities": "^1.2.0",
-    "pg": "7.12.1",
+    "pg": "8.3.3",
     "prom-client": "^11.2.1",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "lint": "tslint --project tsconfig.json --format stylish",
     "start": "node build/src/Program.js -c config.yaml",
     "genreg": "node build/src/Program.js -r -c config.yaml",
-    "test": "npm run build && mocha --recursive build/test",
+    "test": "npm run build && mocha -r ts-node/register test/test.ts test/*.ts test/**/*.ts",
     "changelog": "scripts/towncrier.sh",
-    "coverage": "nyc mocha --recursive test/*.ts"
+    "coverage": "nyc mocha -r ts-node/register test/test.ts test/*.ts test/**/*.ts"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "tslint --project tsconfig.json --format stylish",
     "start": "node build/src/Program.js -c config.yaml",
     "genreg": "node build/src/Program.js -r -c config.yaml",
-    "test": "npm run build && mocha -r ts-node/register test/test.ts test/*.ts test/**/*.ts",
+    "test": "mocha -r ts-node/register test/test.ts test/*.ts test/**/*.ts",
     "changelog": "scripts/towncrier.sh",
     "coverage": "nyc mocha -r ts-node/register test/test.ts test/*.ts test/**/*.ts"
   },

--- a/src/GatewayHandler.ts
+++ b/src/GatewayHandler.ts
@@ -203,15 +203,11 @@ export class GatewayHandler {
     private async handleRoomQuery(ev: IGatewayRoomQuery) {
         log.info(`Trying to discover ${ev.roomAlias}`);
         try {
-            // XXX: We should check to see if the room exists in our cache.
-            // We have to join the room, as doing a lookup would not prompt a bridge like freenode
-            // to intervene.
-            const res = await this.bridge.getIntent().getClient().joinRoom(ev.roomAlias);
-            log.info(`Found ${res.roomId}`);
+            const res = await this.bridge.getIntent().getClient().resolveRoomAlias(ev.roomAlias);
+            log.info(`Found ${res.room_id}`);
             if (ev.onlyCheck) {
-                ev.result(null, res.roomId);
+                ev.result(null, res.room_id);
             }
-            this.bridge.getIntent().leave(res.roomId);
         } catch (ex) {
             log.warn("Room not found:", ex);
             ev.result(Error("Room not found"));

--- a/src/GatewayHandler.ts
+++ b/src/GatewayHandler.ts
@@ -125,6 +125,12 @@ export class GatewayHandler {
             return;
         }
         const room = await this.getVirtualRoom(context.matrix.getId(), this.bridge.getIntent());
+        if (this.bridge.getBot().isRemoteUser(event.state_key)) {
+            // This might be a kick or ban.
+            log.info(`Forwarding remote membership for ${event.state_key} in ${chatName}`);
+            this.purple.gateway.sendMatrixMembership(chatName, event, room);
+            return;
+        }
         const existingMembership = room.membership.find((ev) => ev.stateKey === event.state_key);
         if (existingMembership) {
             if (existingMembership.membership === event.content.membership) {

--- a/src/MatrixEventHandler.ts
+++ b/src/MatrixEventHandler.ts
@@ -1,5 +1,5 @@
-import { Bridge, RemoteUser, MatrixUser, Request, WeakEvent, RoomBridgeStoreEntry } from "matrix-appservice-bridge";
-import { IEventRequestData } from "./MatrixTypes";
+import { Bridge, RemoteUser, MatrixUser, Request, WeakEvent, RoomBridgeStoreEntry, UserMembership } from "matrix-appservice-bridge";
+import { MatrixMembershipEvent, MatrixMessageEvent } from "./MatrixTypes";
 import { MROOM_TYPE_UADMIN, MROOM_TYPE_IM, MROOM_TYPE_GROUP,
     IRemoteUserAdminData } from "./store/Types";
 import { BifrostProtocol } from "./bifrost/Protocol";
@@ -119,12 +119,18 @@ export class MatrixEventHandler {
             data: {},
         });
 
-        if (event.type === "m.room.member" && event.content.membership === "join") {
+        let membershipEvent: MatrixMembershipEvent|undefined;
+
+        if (event.type === "m.room.member" && event.state_key?.length && typeof event.content.membership === "string") {
+            membershipEvent = event as MatrixMembershipEvent;
+        }
+
+        if (membershipEvent && membershipEvent.content.membership === "join") {
             this.deduplicator.waitForJoinResolve(event.room_id, event.sender);
         }
 
         const roomType: string|null = ctx.matrix ? ctx.matrix.get("type") : null;
-        const newInvite = !roomType && event.type === "m.room.member" && event.content.membership === "invite";
+        const newInvite = !roomType && membershipEvent?.content.membership === "invite";
         log.debug("Got event (id, type, sender, state_key, roomtype):", event.event_id, event.type, event.sender, event.state_key, roomType);
         const bridgeBot = this.bridge.getBot();
         const botUserId = bridgeBot.getUserId();
@@ -204,12 +210,12 @@ export class MatrixEventHandler {
             return;
         }
 
-        if (event.type === "m.room.member" && roomType === MROOM_TYPE_GROUP) {
+        if (membershipEvent && roomType === MROOM_TYPE_GROUP) {
             if (this.bridge.getBot().isRemoteUser(event.sender)) {
                 return; // Don't really care about remote users
             }
             if (["join", "leave"].includes(event.content.membership as string)) {
-                await this.handleJoinLeaveGroup(ctx, event);
+                await this.handleJoinLeaveGroup(ctx, membershipEvent);
             }
         }
 
@@ -234,7 +240,7 @@ export class MatrixEventHandler {
     }
 
     /* NOTE: Command handling should really be it's own class, but I am cutting corners.*/
-    private async handleCommand(args: string[], event: IEventRequestData) {
+    private async handleCommand(args: string[], event: WeakEvent) {
         if (!this.bridge) {
             throw Error('Bridge is not defined');
         }
@@ -343,7 +349,7 @@ return `- ${account.protocol.name} (${username}) [Enabled=${account.isEnabled}] 
         }
     }
 
-    private async handlePlumbingCommand(args: string[], event: IEventRequestData) {
+    private async handlePlumbingCommand(args: string[], event: WeakEvent) {
         if (!this.bridge) {
             throw Error('Bridge is not defined');
         }
@@ -425,7 +431,7 @@ return `- ${account.protocol.name} (${username}) [Enabled=${account.isEnabled}] 
         }
     }
 
-    private async handleInviteForBot(event: IEventRequestData) {
+    private async handleInviteForBot(event: WeakEvent) {
         if (!this.bridge) {
             throw Error('Bridge is not defined');
         }
@@ -464,7 +470,7 @@ Say \`help\` for more commands.
         });*/
     }
 
-    private async handleNewAccount(nameOrId: string, args: string[], event: IEventRequestData) {
+    private async handleNewAccount(nameOrId: string, args: string[], event: WeakEvent) {
         // TODO: Check to see if the user has an account matching this already.
         const protocol = this.purple.findProtocol(nameOrId);
         if (protocol === undefined) {
@@ -488,7 +494,7 @@ Say \`help\` for more commands.
         });
     }
 
-    private async handleAddExistingAccount(protocolId: string, name: string, event: IEventRequestData) {
+    private async handleAddExistingAccount(protocolId: string, name: string, event: WeakEvent) {
         // TODO: Check to see if the user has an account matching this already.
         if (protocolId === undefined) {
             throw Error("You need to specify a protocol");
@@ -522,7 +528,7 @@ Say \`help\` for more commands.
         acct.setEnabled(enable);
     }
 
-    private async handleImMessage(context: RoomBridgeStoreEntry, event: IEventRequestData) {
+    private async handleImMessage(context: RoomBridgeStoreEntry, event: WeakEvent) {
         log.info("Handling IM message");
             if (!context.remote) {
             throw Error('Cannot handle message, remote or matrix not defined');
@@ -537,11 +543,11 @@ Say \`help\` for more commands.
         }
         const recipient: string = context.remote.get("recipient");
         log.info(`Sending IM to ${recipient}`);
-        const msg = MessageFormatter.matrixEventToBody(event, this.config.bridge);
+        const msg = MessageFormatter.matrixEventToBody(event as MatrixMessageEvent, this.config.bridge);
         acct.sendIM(recipient, msg);
     }
 
-    private async handleGroupMessage(context: RoomBridgeStoreEntry, event: IEventRequestData) {
+    private async handleGroupMessage(context: RoomBridgeStoreEntry, event: WeakEvent) {
         if (!context.remote || !context.matrix) {
             throw Error('Cannot handle message, remote or matrix not defined');
         }
@@ -553,7 +559,7 @@ Say \`help\` for more commands.
         const isGateway: boolean = context.remote.get("gateway");
         const name: string = context.remote.get("room_name");
         if (isGateway) {
-            const msg = MessageFormatter.matrixEventToBody(event, this.config.bridge);
+            const msg = MessageFormatter.matrixEventToBody(event as MatrixMessageEvent, this.config.bridge);
             this.gatewayHandler.sendMatrixMessage(name, event.sender, msg, context);
             return;
         }
@@ -569,7 +575,7 @@ Say \`help\` for more commands.
                 await this.joinOrDefer(acct, name, props);
             }
             const roomName: string = context.remote.get("room_name");
-            const msg = MessageFormatter.matrixEventToBody(event, this.config.bridge);
+            const msg = MessageFormatter.matrixEventToBody(event as MatrixMessageEvent, this.config.bridge);
             let nick = "";
             // XXX: Gnarly way of trying to determine who we are.
             try {
@@ -600,27 +606,26 @@ Say \`help\` for more commands.
         }
     }
 
-    private async handleJoinLeaveGroup(context: RoomBridgeStoreEntry, event: IEventRequestData) {
+    private async handleJoinLeaveGroup(context: RoomBridgeStoreEntry, event: MatrixMembershipEvent) {
         if (!context.remote) {
             throw Error('No remote context for room');
         }
         if (!this.bridge) {
             throw Error('bridge is not defined yet')
         }
-        // XXX: We are assuming here that the previous state was invite.
-        const membership = event.content.membership;
+        const membership: string = event.content.membership as string;
+        if (!event.state_key || !membership) {
+            return;
+        }
         log.info(`Handling group ${event.sender} ${membership}`);
         let acct: IBifrostAccount;
         const isGateway: boolean = context.remote.get("gateway");
         const name: string = context.remote.get("room_name");
         const roomProtocol: string = context.remote.get("protocol_id");
         if (isGateway) {
-            const displayname = event.content.displayname ||
-                (await this.bridge.getIntent().getProfileInfo(event.sender)).displayname;
             this.gatewayHandler.sendMatrixMembership(
-                name, event.sender, displayname, membership, context,
+                name, context, event,
             );
-            return;
         }
 
         try {
@@ -648,7 +653,7 @@ Say \`help\` for more commands.
         }
     }
 
-    private async handleStateEv(context: RoomBridgeStoreEntry, event: IEventRequestData) {
+    private async handleStateEv(context: RoomBridgeStoreEntry, event: WeakEvent) {
         if (!context.remote) {
             throw Error('No remote context for room');
         }
@@ -664,7 +669,7 @@ Say \`help\` for more commands.
         // XXX: Support state changes for non-gateways
     }
 
-    private async handleJoin(args: string[], event: IEventRequestData) {
+    private async handleJoin(args: string[], event: WeakEvent) {
         if (!this.bridge) {
             throw Error('Cannot handle handleJoin, bridge not defined');
         }

--- a/src/MatrixEventHandler.ts
+++ b/src/MatrixEventHandler.ts
@@ -216,6 +216,7 @@ export class MatrixEventHandler {
             }
             if (["join", "leave"].includes(event.content.membership as string)) {
                 await this.handleJoinLeaveGroup(ctx, membershipEvent);
+                return;
             }
         }
 
@@ -623,9 +624,10 @@ Say \`help\` for more commands.
         const name: string = context.remote.get("room_name");
         const roomProtocol: string = context.remote.get("protocol_id");
         if (isGateway) {
-            this.gatewayHandler.sendMatrixMembership(
+            await this.gatewayHandler.sendMatrixMembership(
                 name, context, event,
             );
+            return;
         }
 
         try {

--- a/src/MatrixRoomHandler.ts
+++ b/src/MatrixRoomHandler.ts
@@ -18,7 +18,7 @@ import { ProtoHacks } from "./ProtoHacks";
 import { IStore } from "./store/Store";
 import { Deduplicator } from "./Deduplicator";
 import { Config } from "./Config";
-import * as entityDecode from "parse-entities";
+import entityDecode from "parse-entities";
 import { MessageFormatter } from "./MessageFormatter";
 const log = Logging.get("MatrixRoomHandler");
 

--- a/src/MatrixRoomHandler.ts
+++ b/src/MatrixRoomHandler.ts
@@ -83,6 +83,7 @@ export class MatrixRoomHandler {
                 storeUser.mxId,
                 this.purple.getProtocol(storeUser.protocol_id)!,
                 storeUser.remoteId,
+                storeUser.data,
             );
         });
         this.remoteEventIdMapping = new Map();

--- a/src/MatrixTypes.ts
+++ b/src/MatrixTypes.ts
@@ -1,26 +1,8 @@
-/**
- * This should really live in matrix-appservice-bridge but that would be a lot of faff
- * and timing is of the essence.
- * - Half-Shot
- */
-import { MatrixUser, RemoteUser, MatrixRoom, RemoteRoom, WeakEvent } from "matrix-appservice-bridge";
+import { MatrixUser, RemoteUser, MatrixRoom, RemoteRoom, WeakEvent, UserMembership } from "matrix-appservice-bridge";
 
  /**
   * This is actually just a matrix event, as far as we care.
   */
-export interface IEventRequestData {
-    event_id: string;
-    origin_server_ts: number;
-    sender: string;
-    type: string;
-    // tslint:disable-next-line:no-any
-    content: any;
-    // tslint:disable-next-line:no-any
-    unsigned?: any;
-    room_id: string;
-    state_key?: string;
-}
-
 export interface IPublicRoomsResponse {
     total_room_count_estimate: number;
     chunk: IPublicRoom[];
@@ -37,4 +19,29 @@ export interface IPublicRoom {
     guest_can_join: boolean; // Whether guest users may join the room and participate in it.
                              // If they can, they will be subject to ordinary power level rules like any other user.
     avatar_url: string|undefined; // The URL for the room's avatar, if one is set.
+}
+
+
+export interface MatrixMembershipEvent extends WeakEvent {
+    content: {
+        membership: "join"|"invite"|"leave"|"ban";
+        displayname?: string;
+        avatar_url?: string;
+        reason?: string;
+    }
+    state_key: string;
+}
+
+export interface MatrixMessageEvent extends WeakEvent {
+    content: {
+        body: string;
+        formatted_body?: string;
+        format?: string;
+        msgtype: string;
+        info?: {
+            mimetype?: string;
+            size?: number
+        };
+        url?: string;
+    };
 }

--- a/src/MessageFormatter.ts
+++ b/src/MessageFormatter.ts
@@ -1,10 +1,10 @@
 import { BifrostProtocol } from "./bifrost/Protocol";
 import { PRPL_XMPP } from "./ProtoHacks";
 import { Parser } from "htmlparser2";
-import { Logging } from "matrix-appservice-bridge";
-import { IEventRequestData } from "./MatrixTypes";
+import { Logging, WeakEvent } from "matrix-appservice-bridge";
 import { IConfigBridge } from "./Config";
 import * as request from "request-promise-native";
+import { MatrixMessageEvent } from "./MatrixTypes";
 const log = Logging.get("MessageFormatter");
 
 export interface IMatrixMsgContents {
@@ -40,7 +40,7 @@ export interface IMessageAttachment {
 
 export class MessageFormatter {
 
-    public static matrixEventToBody(event: IEventRequestData, config: IConfigBridge): IBasicProtocolMessage {
+    public static matrixEventToBody(event: MatrixMessageEvent, config: IConfigBridge): IBasicProtocolMessage {
         const body = event.content.body;
         const formatted: {type: string, body: string}[] = [];
         if (event.content.formatted_body) {
@@ -52,7 +52,7 @@ export class MessageFormatter {
         if (event.content.msgtype === "m.emote") {
             return {body: `/me ${body}`, formatted, id: event.event_id};
         }
-        if (["m.file", "m.image", "m.video"].includes(event.content.msgtype)) {
+        if (["m.file", "m.image", "m.video"].includes(event.content.msgtype) && event.content.url) {
             const uriBits = event.content.url.substr("mxc://".length).split("/");
             const url = (config.mediaserverUrl ? config.mediaserverUrl : config.homeserverUrl).replace(/\/$/, "");
             event.content.info = event.content.info || {};

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -50,7 +50,14 @@ class Program {
           },
           registrationPath: "bifrost-registration.yaml",
           generateRegistration: this.generateRegistration,
-          run: this.runBridge.bind(this),
+          run: async (port: number, config: any) => {
+                try {
+                    await this.runBridge(port, config);
+                } catch (ex) {
+                    log.error("Failed to start:", ex);
+                    process.exit(1);
+                }
+          }
         });
         this.cfg = new Config();
         this.deduplicator = new Deduplicator();

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -1,7 +1,6 @@
 import { IChatJoinProperties } from "./bifrost/Events";
-import { Intent } from "matrix-appservice-bridge";
+import { Intent, WeakEvent } from "matrix-appservice-bridge";
 import * as crypto from "crypto";
-import { IEventRequestData } from "./MatrixTypes";
 
 export class Util {
 
@@ -51,14 +50,14 @@ export class Util {
     }
 
     public static async getMessagesBeforeJoin(
-        intent: Intent, roomId: string): Promise<IEventRequestData[]> {
+        intent: Intent, roomId: string): Promise<WeakEvent[]> {
         const client = intent.getClient();
         // Because the JS SDK expects this to be set :/
         client._clientOpts = {
             lazyLoadMembers: false,
         };
         const res = await client._createMessagesRequest(roomId, undefined, undefined, "b");
-        const msgs: IEventRequestData[] = [];
+        const msgs: WeakEvent[] = [];
         for (const msg of res.chunk.reverse()) {
             if (msg.type === "m.room.member" && msg.sender === client.getUserId()) {
                 break;

--- a/src/bifrost/Gateway.ts
+++ b/src/bifrost/Gateway.ts
@@ -16,7 +16,7 @@ export interface IGateway extends IProfileProvider {
     ): void;
     onRemoteJoin(err: string|null, joinId: string, room: IGatewayRoom|undefined, ownMxid: string|undefined,
     ): Promise<void>;
-    reconnectRemoteUser(user: BifrostRemoteUser, room: IGatewayRoom): void;
+    reconnectRemoteUser(user: BifrostRemoteUser, mxId: string, room: IGatewayRoom): void;
     getMxidForRemote(sender: string): string;
 }
 

--- a/src/bifrost/Gateway.ts
+++ b/src/bifrost/Gateway.ts
@@ -1,3 +1,4 @@
+import { MatrixMembershipEvent } from "../MatrixTypes";
 import { IBasicProtocolMessage } from "../MessageFormatter";
 import { BifrostRemoteUser } from "../store/BifrostRemoteUser";
 import { IProfileProvider } from "./Account";
@@ -8,7 +9,7 @@ export interface IGateway extends IProfileProvider {
         sender: string, body: IBasicProtocolMessage, room: IGatewayRoom,
     ): void;
     sendMatrixMembership(
-        chatName: string, sender: string, displayname: string, membership: string, room: IGatewayRoom,
+        chatName: string, event: MatrixMembershipEvent, room: IGatewayRoom,
     ): void;
     sendStateChange(
         chatName: string, sender: string, type: "topic"|"name"|"avatar", room: IGatewayRoom,
@@ -24,6 +25,12 @@ export interface IGatewayRoom {
     topic: string;
     avatar?: string;
     roomId: string;
-    membership: any[];
+    membership: {
+        sender: string;
+        stateKey: string;
+        displayname?: string;
+        membership: string;
+        isRemote: boolean;
+    }[];
     // remotes: string[];
 }

--- a/src/purple/PurpleInstance.ts
+++ b/src/purple/PurpleInstance.ts
@@ -3,7 +3,7 @@ import { helper, plugins, messaging, Conversation } from "node-purple";
 import { EventEmitter } from "events";
 import { PurpleAccount } from "./PurpleAccount";
 import { IBifrostInstance } from "../bifrost/Instance";
-import { Logging, WeakEvent } from "matrix-appservice-bridge";
+import { Logging } from "matrix-appservice-bridge";
 import * as path from "path";
 import { IConfigPurple } from "../Config";
 import { IUserInfo, IConversationEvent, IEventBody } from "../bifrost/Events";

--- a/src/purple/PurpleInstance.ts
+++ b/src/purple/PurpleInstance.ts
@@ -3,12 +3,11 @@ import { helper, plugins, messaging, Conversation } from "node-purple";
 import { EventEmitter } from "events";
 import { PurpleAccount } from "./PurpleAccount";
 import { IBifrostInstance } from "../bifrost/Instance";
-import { Logging } from "matrix-appservice-bridge";
+import { Logging, WeakEvent } from "matrix-appservice-bridge";
 import * as path from "path";
 import { IConfigPurple } from "../Config";
 import { IUserInfo, IConversationEvent, IEventBody } from "../bifrost/Events";
 import { BifrostProtocol } from "../bifrost/Protocol";
-import { IEventRequestData } from "../MatrixTypes";
 const log = Logging.get("PurpleInstance");
 
 export class PurpleInstance extends EventEmitter implements IBifrostInstance {
@@ -101,11 +100,11 @@ export class PurpleInstance extends EventEmitter implements IBifrostInstance {
         throw Error("Not implemented yet");
     }
 
-    public pushEvent(ev: IEventRequestData) {
+    public pushEvent() {
         // This is for gateways, and we aren't a gateway yet.
     }
 
-    public eventAck(eventName: string, data: IEventBody) {
+    public eventAck() {
         // This is for handling stuff after an event has been sent.
     }
 

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -40,7 +40,7 @@ export interface IStore {
 
     getRoomsOfType(type: MROOM_TYPES): Promise<RoomBridgeStoreEntry[]>;
 
-    storeGhost(userId: string, protocol: BifrostProtocol, username: string)
+    storeGhost(userId: string, protocol: BifrostProtocol, username: string, extraData?: any)
         : Promise<{remote: BifrostRemoteUser, matrix: MatrixUser}>;
     storeAccount(userId: string, protocol: BifrostProtocol, username: string, extraData?: any): Promise<void>;
     removeRoomByRoomId(matrixId: string): Promise<void>;

--- a/src/store/postgres/PgDatastore.ts
+++ b/src/store/postgres/PgDatastore.ts
@@ -272,14 +272,18 @@ export class PgDataStore implements IStore {
     }
 
     public async storeGhost(
-        userId: string, protocol: BifrostProtocol, username: string,
+        userId: string, protocol: BifrostProtocol, username: string, extraData?: any,
     ): Promise<{remote: BifrostRemoteUser, matrix: MatrixUser}> {
         const acctProps = {
             user_id: userId,
             sender_name: username,
             protocol_id: protocol.id,
+            extra_data: "{}",
         // tslint:disable-next-line: no-any
         } as any;
+        if (extraData) {
+            acctProps.extra_data = JSON.stringify(extraData) ;
+        }
         const statement = PgDataStore.BuildUpsertStatement("remote_users", "(user_id)", Object.keys(acctProps));
         await this.pgPool.query(statement, Object.values(acctProps));
         return {
@@ -459,6 +463,7 @@ export class PgDataStore implements IStore {
     }
 
     private async getSchemaVersion(): Promise<number> {
+        log.debug("Fetching schema version");
         try {
             const { rows } = await this.pgPool.query("SELECT version FROM SCHEMA");
             return rows[0].version;

--- a/src/xmppjs/GatewayMUCMembership.ts
+++ b/src/xmppjs/GatewayMUCMembership.ts
@@ -9,6 +9,7 @@ export interface IGatewayMemberXmpp extends IGatewayMember {
     type: "xmpp";
     realJid: JID;
     devices: Set<string>;
+    matrixId: string;
 }
 
 export interface IGatewayMemberMatrix extends IGatewayMember {
@@ -42,8 +43,18 @@ export class GatewayMUCMembership {
         return member;
     }
 
+    public getXmppMemberByMatrixId(chatName: string, matrixId: string): IGatewayMemberXmpp|undefined {
+        // Strip the resource.
+        return this.getXmppMembers(chatName).find((user) => user.matrixId === matrixId);
+    }
+
+
     public getXmppMembers(chatName: string): IGatewayMemberXmpp[] {
         return this.getMembers(chatName).filter((s) => s.type === "xmpp") as IGatewayMemberXmpp[];
+    }
+
+    public getXmppMembersDevices(chatName: string): Set<string> {
+        return new Set(this.getXmppMembers(chatName).map((u) => [...u.devices]).flat());
     }
 
     public getMatrixMembers(chatName: string): IGatewayMemberMatrix[] {
@@ -70,7 +81,7 @@ export class GatewayMUCMembership {
         return true;
     }
 
-    public addXmppMember(chatName: string, realJid: JID, anonymousJid: JID): boolean {
+    public addXmppMember(chatName: string, realJid: JID, anonymousJid: JID, matrixId: string): boolean {
         const member = this.getXmppMemberByRealJid(chatName, realJid.toString());
         if (member) {
             member.devices.add(realJid.toString());
@@ -82,6 +93,7 @@ export class GatewayMUCMembership {
             anonymousJid,
             realJid: jid(`${realJid.local}@${realJid.domain}`),
             devices: new Set([realJid.toString()]),
+            matrixId,
         } as IGatewayMemberXmpp);
         this.members.set(chatName, set);
         return true;

--- a/src/xmppjs/GatewayMUCMembership.ts
+++ b/src/xmppjs/GatewayMUCMembership.ts
@@ -118,16 +118,18 @@ export class GatewayMUCMembership {
     }
 
     public removeXmppMember(chatName: string, realJid: string|JID): boolean {
-        realJid = realJid.toString();
+        realJid = typeof(realJid) === "string" ? jid(realJid) : realJid;
         const member = this.getXmppMemberByRealJid(chatName, realJid);
         if (!member) {
             return false;
         }
-        member.devices.delete(realJid.toString());
-        if (member.devices.size) {
-            return false;
+        if (realJid.resource) {
+            member.devices.delete(realJid.toString());
+            if (member.devices.size) {
+                return false;
+            }
         }
-        const set = this.members.get(chatName)!;
-        return set.delete(member);
+        const set = this.members.get(chatName);
+        return set ? set.delete(member) : true;
     }
 }

--- a/src/xmppjs/GatewayStateResolve.ts
+++ b/src/xmppjs/GatewayStateResolve.ts
@@ -8,7 +8,7 @@ import { XMPPStatusCode } from "./StatusCodes";
 const log = Logging.get("GatewayStateResolve");
 
 function sendToAllDevices(presence: StzaPresenceItem, devices: Set<string>) {
-    return [...devices].map((deviceJid) => 
+    return [...devices].map((deviceJid) =>
         new StzaPresenceItem(
             presence.from,
             deviceJid,
@@ -40,7 +40,6 @@ export class GatewayStateResolve {
                 return [];
             }
             // Matrix Join
-            const from = `${chatName}/` + (event.content.displayname || event.state_key);
             members.addMatrixMember(chatName, event.state_key, jid(from));
             // Reflect to all
             stanzas = sendToAllDevices(

--- a/src/xmppjs/GatewayStateResolve.ts
+++ b/src/xmppjs/GatewayStateResolve.ts
@@ -1,0 +1,109 @@
+import jid from "@xmpp/jid";
+import { Logging } from "matrix-appservice-bridge";
+import { MatrixMembershipEvent } from "../MatrixTypes";
+import { GatewayMUCMembership } from "./GatewayMUCMembership";
+import { IStza, PresenceAffiliation, PresenceRole, StzaBase, StzaPresenceItem } from "./Stanzas";
+import { XMPPStatusCode } from "./StatusCodes";
+
+const log = Logging.get("GatewayStateResolve");
+
+function sendToAllDevices(presence: StzaPresenceItem, devices: Set<string>) {
+    return [...devices].map((deviceJid) => 
+        new StzaPresenceItem(
+            presence.from,
+            deviceJid,
+            undefined,
+            presence.affiliation,
+            presence.role,
+            false,
+            undefined,
+            presence.presenceType,
+        )
+    )
+
+}
+
+export class GatewayStateResolve {
+    static async resolveMatrixStateToXMPP(chatName: string, members: GatewayMUCMembership, event: MatrixMembershipEvent): Promise<IStza[]> {
+        const membership = event.content.membership;
+        let stanzas: IStza[] = [];
+        const allDevices = members.getXmppMembersDevices(chatName);
+        const from = `${chatName}/` + (event.content.displayname || event.state_key);
+        if (allDevices.size === 0) {
+            log.warn("No users found for gateway room!");
+            return stanzas;
+        }
+        const existingMember = members.getMatrixMemberByMatrixId(chatName, event.state_key);
+        if (membership === "join") {
+            if (existingMember) {
+                // Do not handle if we already have them
+                return [];
+            }
+            // Matrix Join
+            const from = `${chatName}/` + (event.content.displayname || event.state_key);
+            members.addMatrixMember(chatName, event.state_key, jid(from));
+            // Reflect to all
+            stanzas = sendToAllDevices(
+                new StzaPresenceItem(
+                    from,
+                    "",
+                    undefined,
+                    PresenceAffiliation.Member,
+                    PresenceRole.Participant
+                ), allDevices,
+            );
+        } else if (membership === "leave" && event.state_key === event.sender) {
+            if (!existingMember) {
+                // Do not handle if we don't have them
+                return [];
+            }
+            // Matrix leave
+            members.removeMatrixMember(chatName, event.state_key);
+                // Reflect to all
+            stanzas = sendToAllDevices(
+                new StzaPresenceItem(
+                    from,
+                    "",
+                    undefined,
+                    PresenceAffiliation.Member,
+                    PresenceRole.None,
+                    false,
+                    undefined,
+                    "unavailable",
+                ), allDevices,
+            );
+        } else if ((membership === "leave" || membership === "ban") && event.state_key !== event.sender) {
+            const kicker = members.getMatrixMemberByMatrixId(chatName, event.sender);
+            const xmppKickee = members.getXmppMemberByMatrixId(chatName, event.state_key);
+            if (existingMember) {
+                // This is Matrix -> Matrix
+                members.removeMatrixMember(chatName, event.state_key);
+                // Reflect to all
+                const presence = new StzaPresenceItem(
+                    from,
+                    "",
+                    undefined,
+                    PresenceAffiliation.None,
+                    PresenceRole.None,
+                    false,
+                    undefined,
+                    "unavailable",
+                );
+                presence.actor = kicker?.anonymousJid.getResource();
+                presence.reason = event.content.reason;
+                presence.statusCodes.add(XMPPStatusCode.SelfKicked);
+                stanzas = sendToAllDevices(presence, allDevices);
+            } else if (xmppKickee) {
+                // This is Matrix -> XMPP
+                members.removeXmppMember(chatName, xmppKickee.realJid.toString());
+                // TODO: Tell the XMPP memeber that it got kicked.
+            } else {
+                // We're not sure what this is, nope out to play it safe.
+                return [];
+            }
+        } else if (membership === "invite") {
+            // TODO: Invites
+        }
+        return stanzas;
+    }
+}

--- a/src/xmppjs/PresenceCache.ts
+++ b/src/xmppjs/PresenceCache.ts
@@ -1,6 +1,5 @@
-import * as xml from "@xmpp/xml";
-import * as jid from "@xmpp/jid";
-import { Logging } from "matrix-appservice-bridge";
+import  xml from "@xmpp/xml";
+import jid from "@xmpp/jid";
 import { XMPPStatusCode } from "./StatusCodes";
 
 export interface IPresenceDelta {

--- a/src/xmppjs/PresenceCache.ts
+++ b/src/xmppjs/PresenceCache.ts
@@ -3,8 +3,6 @@ import * as jid from "@xmpp/jid";
 import { Logging } from "matrix-appservice-bridge";
 import { XMPPStatusCode } from "./StatusCodes";
 
-const log = Logging.get("PresenceCache");
-
 export interface IPresenceDelta {
     status?: IPresenceStatus;
     changed: string[];

--- a/src/xmppjs/XHTMLIM.ts
+++ b/src/xmppjs/XHTMLIM.ts
@@ -1,5 +1,5 @@
 import { Parser } from "htmlparser2";
-import * as he from "he";
+import he from "he";
 
 const XMLNS = "http://jabber.org/protocol/xhtml-im";
 

--- a/src/xmppjs/XJSConnection.ts
+++ b/src/xmppjs/XJSConnection.ts
@@ -1,5 +1,5 @@
-import {Component, xml, jid} from "@xmpp/component-core";
-import * as Reconnect from "@xmpp/reconnect";
+import {Component} from "@xmpp/component-core";
+import Reconnect from "@xmpp/reconnect";
 
 export interface IXJSConnectionOptions {
     password: string;

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -298,6 +298,10 @@ export class XmppJsGateway implements IGateway {
             throw Error('ownMxid is not defined');
         }
 
+        // Ensure our membership is accurate.
+        this.updateMatrixMemberListForRoom(chatName, room);
+        const members = this.members.getMembers(chatName);
+
         // Check if the nick conflicts.
         const existingMember = this.members.getMemberByAnonJid(chatName, stanza.attrs.to);
         if (existingMember) {
@@ -335,9 +339,7 @@ export class XmppJsGateway implements IGateway {
 
         // https://xmpp.org/extensions/xep-0045.html#order
         // 1. membership of others.
-        log.debug("Emitting membership of other users");
-        this.updateMatrixMemberListForRoom(chatName, room);
-        const members = this.members.getMembers(chatName);
+        log.debug(`Emitting membership of other users (${members.length})`);
         // Ensure we chunk this
         let sent = 0;
         for (const member of members) {
@@ -438,7 +440,7 @@ export class XmppJsGateway implements IGateway {
         log.debug(`Join complete for ${to}`);
     }
 
-    public reconnectRemoteUser(user: BifrostRemoteUser, room: IGatewayRoom) {
+    public reconnectRemoteUser(user: BifrostRemoteUser, mxUserId: string, room: IGatewayRoom) {
         if (!user.extraData.real_jid) {
             return;
         }
@@ -449,7 +451,7 @@ export class XmppJsGateway implements IGateway {
             user.extraData.room_name,
             jid(user.extraData.real_jid),
             jid(`${user.extraData.handle}`),
-            user.id,
+            mxUserId,
         );
     }
 

--- a/src/xmppjs/XJSInstance.ts
+++ b/src/xmppjs/XJSInstance.ts
@@ -228,8 +228,17 @@ export class XmppJsInstance extends EventEmitter implements IBifrostInstance {
               log.error("Connection to XMPP server was lost..");
               this.connectionWasDropped = true;
           }
-          xLog.debug("status:", status);
+          xLog.info("status:", status);
         });
+
+        xmpp.on("reconnecting", () => {
+            xLog.info("status: reconnecting");
+        });
+
+        xmpp.on("reconnected", () => {
+            xLog.info("status: reconnecting");
+        });
+
 
         if (opts.logRawStream) {
             xmpp.on("input", (input) => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -2,4 +2,6 @@ import {Logging} from "matrix-appservice-bridge";
 
 if (process.argv.includes("--logging")) {
     Logging.configure({console: "debug"});
+} else {
+    Logging.configure({console: "error"});
 }

--- a/test/xmppjs/test_GatewayMUCMembership.ts
+++ b/test/xmppjs/test_GatewayMUCMembership.ts
@@ -51,6 +51,12 @@ describe("GatewayMUCMembership", () => {
             lastDevice = members.removeXmppMember(CHAT_NAME, XMPP_MEMBER_JID_SECOND_DEVICE.toString());
             expect(lastDevice).to.be.true;
         });
+        it("can add two devices, and remove all if the JID is stripped", () => {
+            members.addXmppMember(CHAT_NAME, XMPP_MEMBER_JID, XMPP_MEMBER_ANONYMOUS, XMPP_MEMBER_MXID);
+            members.addXmppMember(CHAT_NAME, XMPP_MEMBER_JID_SECOND_DEVICE, XMPP_MEMBER_ANONYMOUS, XMPP_MEMBER_MXID);
+            const lastDevice = members.removeXmppMember(CHAT_NAME, XMPP_MEMBER_JID_STRIPPED);
+            expect(lastDevice).to.be.true;
+        });
         it("can remove a Matrix member", () => {
             members.addMatrixMember(CHAT_NAME, MATRIX_MEMBER_MXID, MATRIX_MEMBER_ANONYMOUS);
             const removed = members.removeMatrixMember(CHAT_NAME, MATRIX_MEMBER_MXID);

--- a/test/xmppjs/test_GatewayMUCMembership.ts
+++ b/test/xmppjs/test_GatewayMUCMembership.ts
@@ -1,0 +1,92 @@
+import { jid } from "@xmpp/jid";
+import { expect } from "chai";
+import { GatewayMUCMembership } from "../../src/xmppjs/GatewayMUCMembership";
+
+const CHAT_NAME = "mychatname";
+const XMPP_MEMBER_JID = jid("xmpp_bob", "xmpp.example.com", "myresource");
+const XMPP_MEMBER_JID_STRIPPED = jid("xmpp_bob", "xmpp.example.com");
+const XMPP_MEMBER_JID_SECOND_DEVICE = jid("xmpp_bob", "xmpp.example.com", "myresource2");
+const XMPP_MEMBER_ANONYMOUS = jid("mychatname", "xmpp.example.com", "bob");
+const XMPP_MEMBER_MXID = "@_x_xmpp_bob:matrix.example.com";
+
+const MATRIX_MEMBER_MXID = "@alice:matrix.example.com";
+const MATRIX_MEMBER_ANONYMOUS = jid("mychatname", "xmpp.example.com", "alice");
+
+describe("GatewayMUCMembership", () => {
+    let members: GatewayMUCMembership;
+    beforeEach(() => {
+        members = new GatewayMUCMembership();
+    })
+    describe("adding members", () => {
+        it("can add a XMPP member", () => {
+            const firstDevice = members.addXmppMember(CHAT_NAME, XMPP_MEMBER_JID, XMPP_MEMBER_ANONYMOUS, XMPP_MEMBER_MXID);
+            expect(firstDevice).to.be.true;
+        });
+        it("can add another device for the same XMPP member", () => {
+            members.addXmppMember(CHAT_NAME, XMPP_MEMBER_JID, XMPP_MEMBER_ANONYMOUS, XMPP_MEMBER_MXID);
+            const firstDevice = members.addXmppMember(CHAT_NAME, XMPP_MEMBER_JID_SECOND_DEVICE, XMPP_MEMBER_ANONYMOUS, XMPP_MEMBER_MXID);
+            expect(firstDevice).to.be.false;
+        });
+        it("can add a Matrix member", () => {
+            const firstDevice = members.addMatrixMember(CHAT_NAME, MATRIX_MEMBER_MXID, MATRIX_MEMBER_ANONYMOUS);
+            expect(firstDevice).to.be.true;
+        });
+        it("can add another device for the same Matrix member", () => {
+            members.addMatrixMember(CHAT_NAME, MATRIX_MEMBER_MXID, MATRIX_MEMBER_ANONYMOUS);
+            const firstDevice = members.addMatrixMember(CHAT_NAME, MATRIX_MEMBER_MXID, MATRIX_MEMBER_ANONYMOUS);
+            expect(firstDevice).to.be.false;
+        });
+    });
+    describe("removing members", () => {
+        it("can remove a XMPP member", () => {
+            members.addXmppMember(CHAT_NAME, XMPP_MEMBER_JID, XMPP_MEMBER_ANONYMOUS, XMPP_MEMBER_MXID);
+            const lastDevice = members.removeXmppMember(CHAT_NAME, XMPP_MEMBER_JID.toString());
+            expect(lastDevice).to.be.true;
+        });
+        it("can add two devices, and remove one", () => {
+            members.addXmppMember(CHAT_NAME, XMPP_MEMBER_JID, XMPP_MEMBER_ANONYMOUS, XMPP_MEMBER_MXID);
+            members.addXmppMember(CHAT_NAME, XMPP_MEMBER_JID_SECOND_DEVICE, XMPP_MEMBER_ANONYMOUS, XMPP_MEMBER_MXID);
+            let lastDevice = members.removeXmppMember(CHAT_NAME, XMPP_MEMBER_JID.toString());
+            expect(lastDevice).to.be.false;
+            lastDevice = members.removeXmppMember(CHAT_NAME, XMPP_MEMBER_JID_SECOND_DEVICE.toString());
+            expect(lastDevice).to.be.true;
+        });
+        it("can remove a Matrix member", () => {
+            members.addMatrixMember(CHAT_NAME, MATRIX_MEMBER_MXID, MATRIX_MEMBER_ANONYMOUS);
+            const removed = members.removeMatrixMember(CHAT_NAME, MATRIX_MEMBER_MXID);
+            expect(removed).to.be.true;
+        });
+        it("will return false if the Matrix member was not removed", () => {
+            const removed = members.removeMatrixMember(CHAT_NAME, MATRIX_MEMBER_MXID);
+            expect(removed).to.be.false;
+        });
+
+    });
+    describe("finding members", () => {
+        it("can find an XMPP member by real JID", () => {
+            members.addXmppMember(CHAT_NAME, XMPP_MEMBER_JID, XMPP_MEMBER_ANONYMOUS, XMPP_MEMBER_MXID);
+            const member = members.getXmppMemberByRealJid(CHAT_NAME, XMPP_MEMBER_JID);
+            expect(member?.realJid.toString()).to.be.equal(XMPP_MEMBER_JID_STRIPPED.toString());
+            expect(member?.anonymousJid.toString()).to.be.equal(XMPP_MEMBER_ANONYMOUS.toString());
+            expect(member?.matrixId).to.be.equal(XMPP_MEMBER_MXID);
+            expect(member?.devices.size).to.equal(1);
+            expect(member?.devices.values().next().value).to.equal(XMPP_MEMBER_JID.toString())
+        });
+        it("can find an XMPP member by real JID", () => {
+            members.addXmppMember(CHAT_NAME, XMPP_MEMBER_JID, XMPP_MEMBER_ANONYMOUS, XMPP_MEMBER_MXID);
+            const member = members.getXmppMemberByMatrixId(CHAT_NAME, XMPP_MEMBER_MXID);
+            expect(member?.realJid.toString()).to.be.equal(XMPP_MEMBER_JID_STRIPPED.toString());
+            expect(member?.anonymousJid.toString()).to.be.equal(XMPP_MEMBER_ANONYMOUS.toString());
+            expect(member?.matrixId).to.be.equal(XMPP_MEMBER_MXID);
+            expect(member?.devices.size).to.equal(1);
+            expect(member?.devices.values().next().value).to.equal(XMPP_MEMBER_JID.toString())
+        });
+        it("can find a Matrix member by mxId", () => {
+            members.addMatrixMember(CHAT_NAME, MATRIX_MEMBER_MXID, MATRIX_MEMBER_ANONYMOUS);
+            const member = members.getMatrixMemberByMatrixId(CHAT_NAME, MATRIX_MEMBER_MXID);
+            expect(member?.type).to.equal("matrix");
+            expect(member?.anonymousJid.toString()).to.be.equal(MATRIX_MEMBER_ANONYMOUS.toString());
+            expect(member?.matrixId).to.be.equal(MATRIX_MEMBER_MXID);
+        });
+    });
+})

--- a/test/xmppjs/test_Stanzas.ts
+++ b/test/xmppjs/test_Stanzas.ts
@@ -50,9 +50,9 @@ describe("Stanzas", () => {
             assertXML(xml);
             expect(xml).to.equal(
                 `<presence from="foo@bar" to="baz@bar" type='unavailable'>`
-                + "<x xmlns='http://jabber.org/protocol/muc#user'><item affiliation='none' role='none'>"
-                + "<actor nick='Kicky'/><reason>reasonable reason</reason></item><status code='110'/>"
-                + "<status code='307'/></x></presence>",
+                + "<x xmlns='http://jabber.org/protocol/muc#user'><status code='110'/>"
+                + "<status code='307'/><item affiliation='none' role='none'>"
+                + "<actor nick='Kicky'/><reason>reasonable reason</reason></item></x></presence>",
             );
         });
     });

--- a/test/xmppjs/test_XJSGateway.ts
+++ b/test/xmppjs/test_XJSGateway.ts
@@ -22,14 +22,13 @@ function createGateway(config?: IConfigBridge) {
     } as any, config), mockXmpp};
 }
 
-function createMember(stateKey: string, displayname?: string, membership: string = "join") {
+function createMember(stateKey: string, displayname?: string, membership: string = "join", sender?: string) {
     return {
-        state_key: stateKey,
+        stateKey,
         isRemote: stateKey.startsWith("@_xmpp_"),
-        content: {
-            displayname,
-            membership,
-        },
+        displayname,
+        membership,
+        sender: sender || stateKey,
     };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2890,20 +2890,25 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-pg-connection-string@0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-0.1.3.tgz#da1847b20940e42ee1492beaf65d49d91b245df7"
-  integrity sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=
+pg-connection-string@^2.3.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.4.0.tgz#c979922eb47832999a204da5dbe1ebf2341b6a10"
+  integrity sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ==
 
 pg-int8@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
   integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
 
-pg-pool@^2.0.4:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-2.0.10.tgz#842ee23b04e86824ce9d786430f8365082d81c4a"
-  integrity sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg==
+pg-pool@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.2.1.tgz#5f4afc0f58063659aeefa952d36af49fa28b30e0"
+  integrity sha512-BQDPWUeKenVrMMDN9opfns/kZo4lxmSWhIqo+cSAF7+lfi9ZclQbr9vfnlNaPr8wYF3UYjm5X0yPAhbcgqNOdA==
+
+pg-protocol@^1.2.5:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.3.0.tgz#3c8fb7ca34dbbfcc42776ce34ac5f537d6e34770"
+  integrity sha512-64/bYByMrhWULUaCd+6/72c9PMWhiVFs3EVxl9Ct6a3v/U8+rKgqP2w+kKg/BIGgMJyB+Bk/eNivT32Al+Jghw==
 
 pg-types@^2.1.0:
   version "2.2.0"
@@ -2916,15 +2921,16 @@ pg-types@^2.1.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-pg@7.12.1:
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/pg/-/pg-7.12.1.tgz#880636d46d2efbe0968e64e9fe0eeece8ef72a7e"
-  integrity sha512-l1UuyfEvoswYfcUe6k+JaxiN+5vkOgYcVSbSuw3FvdLqDbaoa2RJo1zfJKfPsSYPFVERd4GHvX3s2PjG1asSDA==
+pg@8.3.3:
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.3.3.tgz#0338631ca3c39b4fb425b699d494cab17f5bb7eb"
+  integrity sha512-wmUyoQM/Xzmo62wgOdQAn5tl7u+IA1ZYK7qbuppi+3E+Gj4hlUxVHjInulieWrd0SfHi/ADriTb5ILJ/lsJrSg==
   dependencies:
     buffer-writer "2.0.0"
     packet-reader "1.0.0"
-    pg-connection-string "0.1.3"
-    pg-pool "^2.0.4"
+    pg-connection-string "^2.3.0"
+    pg-pool "^3.2.1"
+    pg-protocol "^1.2.5"
     pg-types "^2.1.0"
     pgpass "1.x"
     semver "4.3.2"


### PR DESCRIPTION
This fixes numerous problems:
 - Remove IEventRequestData in favour of WeakEvent and MatrixMembershipEvent
 - Use enums over strings for stanzas
 - Fix an issue where PostgreSQL would not work because of an old version of the library.
 - Ensure kicks propagate to XMPP
 - Add tests for the gateway membership management class.