### PR TITLE
Send leaves from the anonymous JID

### DIFF
--- a/changelog.d/150.bugfix
+++ b/changelog.d/150.bugfix
@@ -1,0 +1,1 @@
+Send leaves from the anonymous JID, not mxid

--- a/src/xmppjs/GatewayMUCMembership.ts
+++ b/src/xmppjs/GatewayMUCMembership.ts
@@ -17,6 +17,8 @@ export interface IGatewayMemberMatrix extends IGatewayMember {
     matrixId: string;
 }
 
+const FLAT_SUPPORTED = [].flat !== undefined;
+
 /**
  * Handles storage of MUC membership for matrix and xmpp users.
  */
@@ -54,7 +56,11 @@ export class GatewayMUCMembership {
     }
 
     public getXmppMembersDevices(chatName: string): Set<string> {
-        return new Set(this.getXmppMembers(chatName).map((u) => [...u.devices]).flat());
+        if (FLAT_SUPPORTED) {
+            return new Set(this.getXmppMembers(chatName).map((u) => [...u.devices]).flat());
+        } else {
+            return new Set(this.getXmppMembers(chatName).map((u) => [...u.devices]).reduce((acc, val) => [ ...acc, ...val ], []));
+        }
     }
 
     public getMatrixMembers(chatName: string): IGatewayMemberMatrix[] {

--- a/src/xmppjs/GatewayStateResolve.ts
+++ b/src/xmppjs/GatewayStateResolve.ts
@@ -24,7 +24,7 @@ function sendToAllDevices(presence: StzaPresenceItem, devices: Set<string>) {
 }
 
 export class GatewayStateResolve {
-    static async resolveMatrixStateToXMPP(chatName: string, members: GatewayMUCMembership, event: MatrixMembershipEvent): Promise<IStza[]> {
+    static resolveMatrixStateToXMPP(chatName: string, members: GatewayMUCMembership, event: MatrixMembershipEvent): IStza[] {
         const membership = event.content.membership;
         let stanzas: IStza[] = [];
         const allDevices = members.getXmppMembersDevices(chatName);
@@ -68,7 +68,7 @@ export class GatewayStateResolve {
                 // Reflect to all
             stanzas = sendToAllDevices(
                 new StzaPresenceItem(
-                    from,
+                    existingMember.anonymousJid.toString(),
                     "",
                     undefined,
                     PresenceAffiliation.Member,

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -148,7 +148,7 @@ export class XmppJsGateway implements IGateway {
                 }
             });
         }
-
+        this.members.getXmppMembersDevices(chatName)
         users.forEach((xmppUser) => {
             xmppUser.devices!.forEach((device) => {
                 this.xmpp.xmppSend(new StzaMessage(
@@ -238,7 +238,7 @@ export class XmppJsGateway implements IGateway {
     ) {
         log.info(`Got new ${event.content.membership} for ${event.state_key} (from: ${event.sender}) in ${chatName}`);
         // Iterate around each joined member and add the new presence step.
-        const presenceEvents = await GatewayStateResolve.resolveMatrixStateToXMPP(chatName, this.members, event);
+        const presenceEvents = GatewayStateResolve.resolveMatrixStateToXMPP(chatName, this.members, event);
         if (presenceEvents.length === 0) {
             log.info(`Nothing to do for ${event.event_id}`);
             return;

--- a/test/xmppjs/test_GatewayStateResolve.ts
+++ b/test/xmppjs/test_GatewayStateResolve.ts
@@ -1,0 +1,72 @@
+import { jid } from "@xmpp/jid";
+import { expect } from "chai";
+import { PresenceAffiliation, PresenceRole, StzaPresenceItem } from "../../src/xmppjs/Stanzas";
+import { MatrixMembershipEvent } from "../../src/MatrixTypes";
+import { GatewayMUCMembership } from "../../src/xmppjs/GatewayMUCMembership";
+import { GatewayStateResolve } from "../../src/xmppjs/GatewayStateResolve";
+
+const CHAT_NAME = "mychatname";
+const XMPP_MEMBER_JID = jid("xmpp_bob", "xmpp.example.com", "myresource");
+const XMPP_MEMBER_JID_STRIPPED = jid("xmpp_bob", "xmpp.example.com");
+const XMPP_MEMBER_JID_SECOND_DEVICE = jid("xmpp_bob", "xmpp.example.com", "myresource2");
+const XMPP_MEMBER_ANONYMOUS = jid("mychatname", "xmpp.example.com", "bob");
+const XMPP_MEMBER_MXID = "@_x_xmpp_bob:matrix.example.com";
+
+const MATRIX_MEMBER_MXID = "@alice:matrix.example.com";
+const MATRIX_MEMBER_ANONYMOUS = jid("mychatname", "xmpp.example.com", "alice");
+
+const generateMember = (membership: "join"|"leave", mxid: string): MatrixMembershipEvent => {
+    return {
+        sender: mxid,
+        state_key: mxid,
+        content: {
+            membership,
+        },
+        room_id: "!foo:bar",
+        origin_server_ts: 123456,
+        event_id: "$abc:def",
+        type: "m.room.member",
+    };
+};
+
+describe("GatewayStateResolve", () => {
+    let members: GatewayMUCMembership;
+    beforeEach(() => {
+        members = new GatewayMUCMembership();
+    });
+    it("will ignore a join for a room without XMPP members", () => {
+        const res = GatewayStateResolve.resolveMatrixStateToXMPP(CHAT_NAME, members, generateMember("join", MATRIX_MEMBER_MXID));
+        expect(res).to.have.lengthOf(0);
+    });
+    it("will handle a Matrix join", () => {
+        members.addXmppMember(CHAT_NAME, XMPP_MEMBER_JID, XMPP_MEMBER_ANONYMOUS, XMPP_MEMBER_MXID);
+        const res = GatewayStateResolve.resolveMatrixStateToXMPP(CHAT_NAME, members, generateMember("join", MATRIX_MEMBER_MXID));
+        expect(res).to.have.lengthOf(1);
+        const presence = res[0] as StzaPresenceItem;
+        expect(presence.to).to.equal(XMPP_MEMBER_JID.toString());
+        expect(presence.from).to.equal(CHAT_NAME + "/" + MATRIX_MEMBER_MXID);
+        expect(presence.role).to.equal(PresenceRole.Participant);
+        expect(presence.affiliation).to.equal(PresenceAffiliation.Member);
+    });
+    it("will ignore a leave for a room without XMPP members", () => {
+        members.addMatrixMember(CHAT_NAME, MATRIX_MEMBER_MXID, MATRIX_MEMBER_ANONYMOUS);
+        const res = GatewayStateResolve.resolveMatrixStateToXMPP(CHAT_NAME, members, generateMember("leave", MATRIX_MEMBER_MXID));
+        expect(res).to.have.lengthOf(0);
+    });
+    it("will ignore a leave for a room if the matrix user wasn't joined", () => {
+        members.addXmppMember(CHAT_NAME, XMPP_MEMBER_JID, XMPP_MEMBER_ANONYMOUS, XMPP_MEMBER_MXID);
+        const res = GatewayStateResolve.resolveMatrixStateToXMPP(CHAT_NAME, members, generateMember("leave", MATRIX_MEMBER_MXID));
+        expect(res).to.have.lengthOf(0);
+    });
+    it("will ignore a leave for a room without XMPP members", () => {
+        members.addXmppMember(CHAT_NAME, XMPP_MEMBER_JID, XMPP_MEMBER_ANONYMOUS, XMPP_MEMBER_MXID);
+        members.addMatrixMember(CHAT_NAME, MATRIX_MEMBER_MXID, MATRIX_MEMBER_ANONYMOUS);
+        const res = GatewayStateResolve.resolveMatrixStateToXMPP(CHAT_NAME, members, generateMember("leave", MATRIX_MEMBER_MXID));
+        expect(res).to.have.lengthOf(1);
+        const presence = res[0] as StzaPresenceItem;
+        expect(presence.to).to.equal(XMPP_MEMBER_JID.toString());
+        expect(presence.from).to.equal(MATRIX_MEMBER_ANONYMOUS.toString());
+        expect(presence.role).to.equal(PresenceRole.None);
+        expect(presence.affiliation).to.equal(PresenceAffiliation.Member);
+    });
+})


### PR DESCRIPTION
Fixes a bug where we would send leaves from the chatname/mxid