### PR TITLE
Support Matrix -> XMPP edits in gateways

### DIFF
--- a/changelog.d/154.feature
+++ b/changelog.d/154.feature
@@ -1,0 +1,1 @@
+Support Matrix -> XMPP edits

--- a/src/MatrixTypes.ts
+++ b/src/MatrixTypes.ts
@@ -32,16 +32,21 @@ export interface MatrixMembershipEvent extends WeakEvent {
     state_key: string;
 }
 
-export interface MatrixMessageEvent extends WeakEvent {
-    content: {
-        body: string;
-        formatted_body?: string;
-        format?: string;
-        msgtype: string;
-        info?: {
-            mimetype?: string;
-            size?: number
-        };
-        url?: string;
+export interface IMatrixMsgContents {
+    msgtype: string;
+    body: string;
+    remote_id?: string;
+    info?: {mimetype: string, size: number};
+    "m.relates_to"?: {
+        "event_id": string,
+        rel_type: "m.replace",
     };
+    "m.new_content"?: IMatrixMsgContents;
+    formatted_body?: string;
+    format?: "org.matrix.custom.html";
+    [key: string]: any|undefined;
+}
+
+export interface MatrixMessageEvent extends WeakEvent {
+    content: IMatrixMsgContents;
 }

--- a/src/MessageFormatter.ts
+++ b/src/MessageFormatter.ts
@@ -27,7 +27,7 @@ export class MessageFormatter {
 
     public static matrixEventToBody(event: MatrixMessageEvent, config: IConfigBridge): IBasicProtocolMessage {
         let content = event.content;
-        let original_message = event.content["m.relates_to"]?.event_id;
+        const originalMessage = event.content["m.relates_to"]?.event_id;
         const formatted: {type: string, body: string}[] = [];
         if (event.content["m.relates_to"]?.rel_type === "m.replace" && event.content["m.new_content"]) {
             // This is an edit!
@@ -59,7 +59,11 @@ export class MessageFormatter {
                 },
             };
         }
-        return {body: content.body, formatted, id: event.event_id, original_message};
+        const newMsg: IBasicProtocolMessage = {body: content.body, formatted, id: event.event_id};
+        if (originalMessage) {
+            newMsg.original_message = originalMessage;
+        }
+        return newMsg;
     }
 
     public static async messageToMatrixEvent(msg: IBasicProtocolMessage, protocol: BifrostProtocol, intent?: any):

--- a/src/MessageFormatter.ts
+++ b/src/MessageFormatter.ts
@@ -4,23 +4,8 @@ import { Parser } from "htmlparser2";
 import { Logging, WeakEvent } from "matrix-appservice-bridge";
 import { IConfigBridge } from "./Config";
 import * as request from "request-promise-native";
-import { MatrixMessageEvent } from "./MatrixTypes";
+import { IMatrixMsgContents, MatrixMessageEvent } from "./MatrixTypes";
 const log = Logging.get("MessageFormatter");
-
-export interface IMatrixMsgContents {
-    msgtype: string;
-    body: string;
-    remote_id?: string;
-    info?: {mimetype: string, size: number};
-    "m.relates_to"?: {
-        "event_id": string,
-        rel_type: "m.replace",
-    };
-    "m.new_content"?: IMatrixMsgContents;
-    formatted_body?: string;
-    format?: "org.matrix.custom.html";
-    [key: string]: any|undefined;
-}
 
 export interface IBasicProtocolMessage {
     body: string;
@@ -41,36 +26,40 @@ export interface IMessageAttachment {
 export class MessageFormatter {
 
     public static matrixEventToBody(event: MatrixMessageEvent, config: IConfigBridge): IBasicProtocolMessage {
-        const body = event.content.body;
+        let content = event.content;
+        let original_message = event.content["m.relates_to"]?.event_id;
         const formatted: {type: string, body: string}[] = [];
-        if (event.content.formatted_body) {
+        if (event.content["m.relates_to"]?.rel_type === "m.replace" && event.content["m.new_content"]) {
+            // This is an edit!
+            content = event.content["m.new_content"];
+        }
+        if (content.formatted_body) {
             formatted.push({
-                body: event.content.formatted_body,
-                type: event.content.format === "org.matrix.custom.html" ? "html" : "unknown",
+                body: content.formatted_body,
+                type: content.format === "org.matrix.custom.html" ? "html" : "unknown",
             });
         }
-        if (event.content.msgtype === "m.emote") {
-            return {body: `/me ${body}`, formatted, id: event.event_id};
+        if (content.msgtype === "m.emote") {
+            return {body: `/me ${content.body}`, formatted, id: event.event_id};
         }
         if (["m.file", "m.image", "m.video"].includes(event.content.msgtype) && event.content.url) {
             const uriBits = event.content.url.substr("mxc://".length).split("/");
             const url = (config.mediaserverUrl ? config.mediaserverUrl : config.homeserverUrl).replace(/\/$/, "");
-            event.content.info = event.content.info || {};
             return {
-                body,
+                body: content.body,
                 id: event.event_id,
                 opts: {
                     attachments: [
                         {
                             uri: `${url}/_matrix/media/v1/download/${uriBits[0]}/${uriBits[1]}`,
-                            mimetype: event.content.info.mimetype,
-                            size: event.content.info.size,
+                            mimetype: event.content.info?.mimetype,
+                            size: event.content.info?.size,
                         },
                     ],
                 },
             };
         }
-        return {body, formatted, id: event.event_id};
+        return {body: content.body, formatted, id: event.event_id, original_message};
     }
 
     public static async messageToMatrixEvent(msg: IBasicProtocolMessage, protocol: BifrostProtocol, intent?: any):

--- a/src/xmppjs/Stanzas.ts
+++ b/src/xmppjs/Stanzas.ts
@@ -201,6 +201,7 @@ export class StzaMessage extends StzaBase {
     public body: string = "";
     public markable: boolean = true;
     public attachments: string[] = [];
+    public replacesId?: string;
     constructor(
         from: string,
         to: string,
@@ -219,6 +220,7 @@ export class StzaMessage extends StzaBase {
                 this.attachments = (idOrMsg.opts.attachments || []).map((a) => a.uri);
             }
             this.id = idOrMsg.id;
+            this.replacesId = idOrMsg.original_message;
         } else if (idOrMsg) {
             this.id = idOrMsg as string;
         }
@@ -240,8 +242,10 @@ export class StzaMessage extends StzaBase {
         }
         // XEP-0333
         const markable = this.markable ? "<markable xmlns='urn:xmpp:chat-markers:0'/>" : "";
+        // XEP-0308
+        const replaces = this.replacesId ? `<replace id='${this.replacesId}' xmlns='urn:xmpp:message-correct:0'/>` : "";
         return `<message from="${this.from}" to="${this.to}" id="${this.id}" ${type}>`
-             + `${this.html}<body>${he.encode(this.body)}</body>${attachments}${markable}</message>`;
+             + `${this.html}<body>${he.encode(this.body)}</body>${attachments}${markable}${replaces}</message>`;
     }
 }
 

--- a/src/xmppjs/Stanzas.ts
+++ b/src/xmppjs/Stanzas.ts
@@ -220,7 +220,9 @@ export class StzaMessage extends StzaBase {
                 this.attachments = (idOrMsg.opts.attachments || []).map((a) => a.uri);
             }
             this.id = idOrMsg.id;
-            this.replacesId = idOrMsg.original_message;
+            if (idOrMsg.original_message) {
+                this.replacesId = idOrMsg.original_message;
+            }
         } else if (idOrMsg) {
             this.id = idOrMsg as string;
         }

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -148,17 +148,15 @@ export class XmppJsGateway implements IGateway {
                 }
             });
         }
-        this.members.getXmppMembersDevices(chatName)
-        users.forEach((xmppUser) => {
-            xmppUser.devices!.forEach((device) => {
-                this.xmpp.xmppSend(new StzaMessage(
-                    from.anonymousJid.toString(),
-                    device.toString(),
-                    msg,
-                    "groupchat",
-                ));
-            });
-        });
+        const msgs = [...this.members.getXmppMembersDevices(chatName)].map((device) => 
+            new StzaMessage(
+                from.anonymousJid.toString(),
+                device,
+                msg,
+                "groupchat",
+            )
+        );
+        return this.xmpp.xmppSendBulk(msgs);
     }
 
     /**

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -202,12 +202,10 @@ export class XmppJsGateway implements IGateway {
     }
 
     public reflectXMPPStanza(chatName: string, stanza: StzaBase) {
-        const xmppMembers = this.members.getXmppMembers(chatName);
-        xmppMembers.forEach((xmppUser) => {
-            xmppUser.devices!.forEach((device) => {
-                stanza.to = device.toString();
-                this.xmpp.xmppSend(stanza);
-            });
+        const xmppDevices = [...this.members.getXmppMembersDevices(chatName)];
+        xmppDevices.forEach((device) => {
+            stanza.to = device;
+            this.xmpp.xmppSend(stanza);
         });
     }
 
@@ -243,9 +241,7 @@ export class XmppJsGateway implements IGateway {
             log.info(`Nothing to do for ${event.event_id}`);
             return;
         }
-        for (const stza of presenceEvents) {
-            await this.xmpp.xmppSend(stza);
-        }
+        await this.xmpp.xmppSendBulk(presenceEvents);
     }
 
     public sendStateChange(

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -148,7 +148,7 @@ export class XmppJsGateway implements IGateway {
                 }
             });
         }
-        const msgs = [...this.members.getXmppMembersDevices(chatName)].map((device) => 
+        const msgs = [...this.members.getXmppMembersDevices(chatName)].map((device) =>
             new StzaMessage(
                 from.anonymousJid.toString(),
                 device,


### PR DESCRIPTION
We still need to fix the case where you make two edits though, as this will send the wrong eventID on subsequent edits. (Matrix edits are layered, XMPP edits edit the original message)