### PR TITLE
set the user's displayname in the room

### DIFF
--- a/changelog.d/161.feature
+++ b/changelog.d/161.feature
@@ -1,0 +1,1 @@
+Set the user's displayname in the room based on their nickname

--- a/src/GatewayHandler.ts
+++ b/src/GatewayHandler.ts
@@ -197,6 +197,9 @@ export class GatewayHandler {
                 );
             }
             roomId = res.roomId;
+            if (data.nick) {
+                await intent.setRoomUserDisplayName(roomId as string, data.nick);
+            }
             const room = await this.getOrCreateGatewayRoom(data, roomId!);
             const canonAlias = room.remote?.get<IChatJoinProperties>("properties").room_alias;
             if (canonAlias !== data.roomAlias) {

--- a/src/GatewayHandler.ts
+++ b/src/GatewayHandler.ts
@@ -198,7 +198,15 @@ export class GatewayHandler {
             }
             roomId = res.roomId;
             if (data.nick) {
-                await intent.setRoomUserDisplayName(roomId as string, data.nick);
+                // Set the user's displayname in the room to their nickname.
+                // Do this after a short delay, so that we don't have a race on
+                // the server setting the global displayname.
+                setTimeout(
+                    async () => {
+                        await intent.setRoomUserProfile(roomId as string, {displayname: data.nick});
+                    },
+                    1000,
+                );
             }
             const room = await this.getOrCreateGatewayRoom(data, roomId!);
             const canonAlias = room.remote?.get<IChatJoinProperties>("properties").room_alias;


### PR DESCRIPTION
depends on https://github.com/matrix-org/matrix-appservice-bridge/pull/248

fixes #153 

This sets the user's displayname after the user joins.

![image](https://user-images.githubusercontent.com/1012976/95541414-5687a380-09c1-11eb-9884-4790716509a9.png)

There is an issue where the first time a user joins a room, it will set the displayname correctly, but then will immediately reset it to their XMPP localpart:

![image](https://user-images.githubusercontent.com/1012976/95541455-74ed9f00-09c1-11eb-9fc9-33c53f0edeee.png)

I suspect that it's because Matrix doesn't actually officially support per-room displaynames, and since it's setting the user's global displayname at around the same time that it sets the user's per-room displayname, the two operations race.  I'm not sure what's the best way to deal with this.  The only thing I can think of is to put the per-room displayname setting in a `setTimeout` for some time that's short enough that it shouldn't annoy users, but long enough that the server won't reset the displayname.