### PR TITLE
Fix multiple attributes in a HTML tag causing messages to fail

### DIFF
--- a/changelog.d/170.bugfix
+++ b/changelog.d/170.bugfix
@@ -1,0 +1,1 @@
+Fix a critical issue where sending HTML with multiple attributes in a tag would cause the message to not be sent

--- a/src/xmppjs/ServiceHandler.ts
+++ b/src/xmppjs/ServiceHandler.ts
@@ -270,6 +270,7 @@ export class ServiceHandler {
             discoInfo.feature.add(XMPPFeatures.DiscoInfo);
             discoInfo.feature.add(XMPPFeatures.Muc);
             discoInfo.feature.add(XMPPFeatures.MessageCorrection);
+            discoInfo.feature.add(XMPPFeatures.XHTMLIM);
             discoInfo.identity.add({
                 category: "conference",
                 name: alias,

--- a/src/xmppjs/XHTMLIM.ts
+++ b/src/xmppjs/XHTMLIM.ts
@@ -65,7 +65,7 @@ export class XHTMLIM {
                 if (tagname === "html") {
                     attribs.xmlns = XMLNS;
                 }
-                xhtml += `<${tagname}${Object.keys(attribs).map((k) => ` ${k}='${attribs[k]}'`)}>`;
+                xhtml += `<${tagname}${Object.keys(attribs).map((k) => ` ${k}='${attribs[k]}'`).join("")}>`;
             },
             ontext: (text) => {
                 xhtml += `${he.escape(text)}`;

--- a/src/xmppjs/XMPPConstants.ts
+++ b/src/xmppjs/XMPPConstants.ts
@@ -16,4 +16,5 @@ export enum XMPPFeatures {
     IqVersion = "jabber:iq:version",
     IqSearch = "jabber:iq:search",
     MessageCorrection = "urn:xmpp:message-correct:0",
+    XHTMLIM = "http://jabber.org/protocol/xhtml-im",
 }

--- a/test/xmppjs/test_Stanzas.ts
+++ b/test/xmppjs/test_Stanzas.ts
@@ -1,16 +1,8 @@
 import * as Chai from "chai";
 import { StzaPresenceItem, StzaPresenceError, StzaMessageSubject,
     StzaMessage, StzaPresencePart, StzaPresenceKick, SztaIqError } from "../../src/xmppjs/Stanzas";
-import * as parser from "fast-xml-parser";
+import { assertXML } from "./util";
 const expect = Chai.expect;
-
-function assertXML(xml) {
-    const err = parser.validate(xml);
-    if (err !== true) {
-        // console.error(xml);
-        throw new Chai.AssertionError(err.err.code + ": " + err.err.msg);
-    }
-}
 
 describe("Stanzas", () => {
     describe("StzaPresenceItem", () => {

--- a/test/xmppjs/test_XHTMLIM.ts
+++ b/test/xmppjs/test_XHTMLIM.ts
@@ -1,5 +1,6 @@
 import * as Chai from "chai";
 import { XHTMLIM } from "../../src/xmppjs/XHTMLIM";
+import { assertXML } from "./util";
 
 const expect = Chai.expect;
 
@@ -49,4 +50,11 @@ describe("XHTMLIM", () => {
             + " this is a reply</html>",
         );
     });
+    //
+    it("should transform an inline image", () => {
+        const xhtmlValue = XHTMLIM.HTMLToXHTML("Here is a pretty image<span class=\"d-emoji\"><img alt=\"shadow\" title=\"shadow\" height=\"32\" src=\"http://foobar.com\" /></span>");
+        assertXML(xhtmlValue);
+        expect(xhtmlValue).to.equal("<html xmlns='http://jabber.org/protocol/xhtml-im'>Here is a pretty image<span class='d-emoji'>" +
+            "<img alt='shadow' title='shadow' height='32' src='http://foobar.com'></img></span></html>");
+    })
 });

--- a/test/xmppjs/util.ts
+++ b/test/xmppjs/util.ts
@@ -1,0 +1,9 @@
+import * as parser from "fast-xml-parser";
+import { AssertionError } from "chai";
+
+export function assertXML(xml) {
+    const err = parser.validate(xml);
+    if (err !== true) {
+        throw new AssertionError(err.err.code + ": " + err.err.msg);
+    }
+}


### PR DESCRIPTION
There was a bit of logic in the bridge that would cause attributes for a tag to include a comma between them, which isn't valid XML. 