### PR TITLE
Replace various intent.getClient().foo calls with intent.foo() calls

### DIFF
--- a/changelog.d/181.bugfix
+++ b/changelog.d/181.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where joining a room through the XMPP gateway would sometimes fail if the user was invited

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "htmlparser2": "^4.1.0",
     "leven": "^3.1.0",
     "marked": "^1.2.0",
-    "matrix-appservice-bridge": "^2.2.0",
+    "matrix-appservice-bridge": "^2.3.0-rc2",
     "parse-entities": "^1.2.0",
     "pg": "8.3.3",
     "prom-client": "^11.2.1",

--- a/src/GatewayHandler.ts
+++ b/src/GatewayHandler.ts
@@ -187,24 +187,18 @@ export class GatewayHandler {
             if (this.config.tuning.waitOnProfileBeforeSend) {
                 await this.profileSync.updateProfile(protocol, data.sender, this.purple.gateway);
             }
-            const res = await intent.getClient().joinRoom(data.roomAlias, {syncRoom: false});
+            roomId = await intent.join(data.roomAlias);
             if (!this.config.tuning.waitOnProfileBeforeSend) {
                 await this.profileSync.updateProfile(protocol, data.sender, this.purple.gateway);
             }
-            if (!res || !res.roomId) {
-                throw Error(
-                    "Roomid not given in join",
-                );
-            }
-            roomId = res.roomId;
-            const room = await this.getOrCreateGatewayRoom(data, roomId!);
+            const room = await this.getOrCreateGatewayRoom(data, roomId);
             const canonAlias = room.remote?.get<IChatJoinProperties>("properties").room_alias;
             if (canonAlias !== data.roomAlias) {
                 throw Error(
                     "We do not support multiple room aliases, try " + canonAlias,
                 );
             }
-            const vroom = await this.getVirtualRoom(roomId!, intent);
+            const vroom = await this.getVirtualRoom(roomId, intent);
             await this.purple.gateway.onRemoteJoin(null, data.join_id, vroom, intentUser);
         } catch (ex) {
             if (roomId) {

--- a/src/MessageFormatter.ts
+++ b/src/MessageFormatter.ts
@@ -128,7 +128,7 @@ export class MessageFormatter {
                 if (!attachment.size) {
                     attachment.size = parseInt(file.headers["content-length"] || "0", 10);
                 }
-                const maxSize = 
+                const maxSize =
                     (await intent.getClient().getMediaConfig().then((cfg) => cfg.m.upload.size).catch(() => -1));
 
                 if (attachment.size && maxSize > -1 && maxSize < attachment.size!) {

--- a/src/MessageFormatter.ts
+++ b/src/MessageFormatter.ts
@@ -1,7 +1,7 @@
 import { BifrostProtocol } from "./bifrost/Protocol";
 import { PRPL_XMPP } from "./ProtoHacks";
 import { Parser } from "htmlparser2";
-import { Logging, WeakEvent } from "matrix-appservice-bridge";
+import { Intent, Logging } from "matrix-appservice-bridge";
 import { IConfigBridge } from "./Config";
 import * as request from "request-promise-native";
 import { IMatrixMsgContents, MatrixMessageEvent } from "./MatrixTypes";
@@ -66,7 +66,7 @@ export class MessageFormatter {
         return newMsg;
     }
 
-    public static async messageToMatrixEvent(msg: IBasicProtocolMessage, protocol: BifrostProtocol, intent?: any):
+    public static async messageToMatrixEvent(msg: IBasicProtocolMessage, protocol: BifrostProtocol, intent?: Intent):
         Promise<IMatrixMsgContents> {
         log.debug("Got message:", msg);
         const matrixMsg: IMatrixMsgContents = {
@@ -128,9 +128,8 @@ export class MessageFormatter {
                 if (!attachment.size) {
                     attachment.size = parseInt(file.headers["content-length"] || "0", 10);
                 }
-                const client = intent.getClient();
-                const maxSize = client.getMediaConfig ?
-                    (await client.getMediaConfig().then((cfg) => cfg.m.upload.size).catch(() => -1)) : -1;
+                const maxSize = 
+                    (await intent.getClient().getMediaConfig().then((cfg) => cfg.m.upload.size).catch(() => -1));
 
                 if (attachment.size && maxSize > -1 && maxSize < attachment.size!) {
                     log.info("File is too large, linking instead");
@@ -139,10 +138,8 @@ export class MessageFormatter {
                 }
 
                 log.info(`Uploading ${attachment.uri}...`);
-                const mxcurl = await intent.getClient().uploadContent(file.body, {
-                    onlyContentUri: true,
+                const mxcurl = await intent.uploadContent(file.body, {
                     includeFilename: false,
-                    rawResponse: false,
                     type: attachment.mimetype || "application/octect-stream",
                 });
                 matrixMsg.url = mxcurl;

--- a/src/ProfileSync.ts
+++ b/src/ProfileSync.ts
@@ -83,11 +83,9 @@ export class ProfileSync {
             log.debug(`Got an avatar, setting`);
             try {
                 const {type, data} = await account.getAvatarBuffer(remoteProfileSet.avatar_uri, senderId);
-                const mxcUrl = await intent.getClient().uploadContent(data, {
+                const mxcUrl = await intent.uploadContent(data, {
                     name: path.basename(remoteProfileSet.avatar_uri),
                     type,
-                    rawResponse: false,
-                    onlyContentUri: true,
                 });
                 await intent.setAvatarUrl(mxcUrl);
                 matrixUser.set("avatar_url", remoteProfileSet.avatar_uri);

--- a/test/mocks/intent.ts
+++ b/test/mocks/intent.ts
@@ -11,21 +11,17 @@ export class MockIntent {
         this.ensureRegisteredCalled = true;
     }
 
-    public getClient() {
-        return {
-            joinRoom: (roomString: string, opts: any) => {
-                this.clientJoinRoomCalledWith = {roomString, opts};
-                roomString = roomString.startsWith("#") ? roomString.replace("#", "!") : roomString;
-                return {roomId: roomString};
-            },
-        };
-    }
-
     public async leave(roomString: string) {
         this.leftRoom = roomString;
     }
 
     public async roomState(roomId: string) {
         return [];
+    }
+
+    public async join(roomString: string, opts: any) {
+        this.clientJoinRoomCalledWith = {roomString, opts};
+        roomString = roomString.startsWith("#") ? roomString.replace("#", "!") : roomString;
+        return roomString;
     }
 }

--- a/test/test_messageformatter.ts
+++ b/test/test_messageformatter.ts
@@ -12,17 +12,11 @@ const XMPP = new BifrostProtocol({
 });
 
 const intent = {
-    getClient: () => {
-        return {
-            uploadContent: (content) => {
-                return Promise.resolve("mxc://abc/def");
-            },
-            getMediaConfig: () => {
-                return Promise.resolve({"m.upload.size": 1024});
-            },
-        };
-    },
-};
+    uploadContent: async () => "mxc://abc/def",
+    getClient: () => ({
+        getMediaConfig: async () => ({"m.upload.size": 1024}),
+    }),
+} as any;
 
 describe("MessageFormatter", () => {
     describe("matrixEventToBody", () => {

--- a/test/test_profilesync.ts
+++ b/test/test_profilesync.ts
@@ -32,13 +32,9 @@ function createProfileSync(userInfo?: {}) {
                 setAvatarUrl: (avatarUrl) => {
                     values.avatarUrl = avatarUrl;
                 },
-                getClient: () => {
-                    return {
-                        uploadContent: (data) => {
-                            values.uploadedData = data;
-                            return "mxc://example.com/foobar";
-                        },
-                    };
+                uploadContent: (data) => {
+                    values.uploadedData = data;
+                    return "mxc://example.com/foobar";
                 },
             };
         },
@@ -65,17 +61,6 @@ function createProfileSync(userInfo?: {}) {
         values,
     };
 }
-
-/*
-const {type, data} = await account.getAvatarBuffer(remoteProfileSet.avatar_uri, senderId);
-const mxcUrl = await intent.getClient().uploadContent(data, {
-    name: path.basename(remoteProfileSet.avatar_uri),
-    type,
-    rawResponse: false,
-    onlyContentUri: true,
-});
-await intent.setAvatarUrl(mxcUrl);
- */
 
 describe("ProfileSync", () => {
     it("will sync one profile without any UserInfo", async () => {


### PR DESCRIPTION
This should fix #158, because we were joining through the client call rather than the intent call. This confused the bridge because it wasn't caching the result of the join, and so a call to roomState() would break it.