### PR TITLE
Ensure bridge emits XMPP stanzas in the right order on gateway join

### DIFF
--- a/changelog.d/189.bugfix
+++ b/changelog.d/189.bugfix
@@ -1,0 +1,1 @@
+Ensure stanzas are emitted in the right order when an XMPP user joins a MUC


### PR DESCRIPTION
We were doing things slightly out of order.