### PR TITLE
Fix text stanza element

### DIFF
--- a/src/xmppjs/Stanzas.ts
+++ b/src/xmppjs/Stanzas.ts
@@ -152,7 +152,7 @@ export class StzaPresenceError extends StzaPresence {
     public get presenceContent() {
         return `<error type='${this.errType}' by='${this.by}'><${this.innerError}`
              + " xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>"
-             + (this.text ? `<text>${he.encode(this.text)}</text>` : "")
+             + (this.text ? `<text xmlns="urn:ietf:params:xml:ns:xmpp-stanzas">${he.encode(this.text)}</text>` : "")
              + "</error>";
     }
 }
@@ -440,7 +440,7 @@ export class SztaIqError extends StzaBase {
         return `<iq from='${this.from}' to='${this.to}' id='${this.id}' type='error' xml:lang='en'>`
         + `<error type='${this.errorType}'${errorParams}><${this.innerError} ` +
           "xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>" +
-          (this.text ? `<text>${he.encode(this.text)}</text>` : "") +
+          (this.text ? `<text xmlns="urn:ietf:params:xml:ns:xmpp-stanzas">${he.encode(this.text)}</text>` : "") +
           "</error></iq>";
     }
 }

--- a/test/xmppjs/test_Stanzas.ts
+++ b/test/xmppjs/test_Stanzas.ts
@@ -110,7 +110,7 @@ describe("Stanzas", () => {
         expect(xml).to.equal(
             "<iq from='foo@bar' to='baz@bar' id='someid' type='error' xml:lang='en'>" +
              "<error type='cancel' by='foo'><not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>" +
-             "<text>Something isn&#x27;t right</text>" +
+             `<text xmlns="urn:ietf:params:xml:ns:xmpp-stanzas">Something isn&#x27;t right</text>` +
              "</error></iq>",
         );
     });


### PR DESCRIPTION
Partial fix to #172. Fixing the error text itself as it's the error the bridge library gives us, as the real error not passed through. We'll need to make changes to the matrix-appservice-bridge library in order to extract it.