### PR TITLE
Download files as binary instead of as UTF-8 string

### DIFF
--- a/changelog.d/220.bugfix
+++ b/changelog.d/220.bugfix
@@ -1,0 +1,1 @@
+Download files as binary instead of as UTF-8 string.

--- a/src/MessageFormatter.ts
+++ b/src/MessageFormatter.ts
@@ -120,7 +120,10 @@ export class MessageFormatter {
                     log.warn("Don't know how to handle attachment for message, not a http format uri");
                     return matrixMsg;
                 }
-                const file = (await request.get(attachment.uri, {resolveWithFullResponse: true}).promise())!;
+                const file = (await request.get(attachment.uri, {
+                    resolveWithFullResponse: true,
+                    encoding: null,
+                }).promise())!;
                 // Use the headers if a type isn't given.
                 if (!attachment.mimetype) {
                     attachment.mimetype = file.headers["content-type"];


### PR DESCRIPTION
When `encoding` isn't specified, then `request` returns a string that is the UTF-8 decoding of the response.  We need to specify `encoding: null` to get a `Buffer`.