### PR TITLE
Fixing error in EventHandler

### DIFF
--- a/changelog.d/221.bugfix
+++ b/changelog.d/221.bugfix
@@ -1,0 +1,1 @@
+Fix TypeError in MatrixEventHandler

--- a/src/MatrixEventHandler.ts
+++ b/src/MatrixEventHandler.ts
@@ -452,7 +452,7 @@ return `- ${account.protocol.name} (${username}) [Enabled=${account.isEnabled}] 
         // Check to see if it's a 1 to 1.
         // TODO: Use is_direct
         const members = await this.bridge.getBot().getJoinedMembers(event.room_id);
-        if (Object.keys(members.length).length > 2) {
+        if (Object.keys(members).length > 2) {
             log.info("Room is not a 1 to 1 room: Treating as a potential plumbable room.");
             if (this.config.provisioning.enablePlumbing) {
                 // We don't need to be in the room.


### PR DESCRIPTION
I've got the following error and found the reason in `MatrixEventHandler` where the `length` was used and not the object itself. So it was not possible to start a  1 to 1 room with the bot.
```
Jan-4 18:21:29.172 ERROR MatrixEventHandler Failed to handle invite for bot: TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at MatrixEventHandler.handleInviteForBot (/app/src/MatrixEventHandler.ts:455:20)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at MatrixEventHandler.onEvent (/app/src/MatrixEventHandler.ts:151:21)
```
Signed-off-by: Christopher Lorenz <britiger@gmx.net>