### PR TITLE
Speed up gateway joins

### DIFF
--- a/changelog.d/222.misc
+++ b/changelog.d/222.misc
@@ -1,0 +1,1 @@
+Improve remote gateway join performance

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "htmlparser2": "^4.1.0",
     "leven": "^3.1.0",
     "marked": "^1.2.0",
-    "matrix-appservice-bridge": "^2.3.0-rc3",
+    "matrix-appservice-bridge": "^2.4.1",
     "parse-entities": "^1.2.0",
     "pg": "8.3.3",
     "prom-client": "^11.2.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "parse-entities": "^1.2.0",
     "pg": "8.3.3",
     "prom-client": "^11.2.1",
+    "quick-lru": "^5.1.1",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.5",
     "source-map-support": "^0.5.16",

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -30,6 +30,7 @@ export class Config {
     };
 
     public readonly autoRegistration: IConfigAutoReg = {
+        registrationNameCacheSize: 15000,
         enabled: false,
         protocolSteps: undefined,
     };
@@ -113,6 +114,7 @@ export interface IConfigPurple {
 export interface IConfigAutoReg {
     enabled: boolean;
     protocolSteps: {[protocol: string]: IAutoRegStep} | undefined;
+    registrationNameCacheSize: number;
 }
 
 export interface IConfigBridgeBot {
@@ -144,7 +146,6 @@ export interface IConfigAccessControl {
         whitelist?: string[],
     };
 }
-
 interface IConfigMetrics {
     enabled: boolean;
 }

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -372,7 +372,7 @@ export class XmppJsGateway implements IGateway {
                         false,
                         realJid,
                     ),
-                ) 
+                )
             })());
         }
 

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -348,39 +348,32 @@ export class XmppJsGateway implements IGateway {
         // 1. membership of others.
         log.debug(`Emitting membership of other users (${members.length})`);
         // Ensure we chunk this
-        let sent = 0;
         const allMembershipPromises: Promise<unknown>[] = [];
         for (const member of members) {
-            sent++;
             if (member.anonymousJid.toString() === stanza.attrs.to) {
                 continue;
             }
-            if (sent % 100 === 0) {
-                try {
-                    await this.xmpp.xmppWaitForDrain(250);
-                } catch (ex) {
-                    log.warn("Drain didn't arrive, oh well");
+            allMembershipPromises.push((async () => {
+                let realJid;
+                if ((member as IGatewayMemberXmpp).realJid) {
+                    realJid = (member as IGatewayMemberXmpp).realJid.toString();
+                } else {
+                    realJid = this.registration.generateParametersFor(
+                        XMPP_PROTOCOL.id, (member as IGatewayMemberMatrix).matrixId,
+                    ).username;
                 }
-            }
-            let realJid;
-            if ((member as IGatewayMemberXmpp).realJid) {
-                realJid = (member as IGatewayMemberXmpp).realJid.toString();
-            } else {
-                realJid = this.registration.generateParametersFor(
-                    XMPP_PROTOCOL.id, (member as IGatewayMemberMatrix).matrixId,
-                ).username;
-            }
-            allMembershipPromises.push(this.xmpp.xmppSend(
-                new StzaPresenceItem(
-                    member.anonymousJid.toString(),
-                    stanza.attrs.from,
-                    undefined,
-                    PresenceAffiliation.Member,
-                    PresenceRole.Participant,
-                    false,
-                    realJid,
-                ),
-            ));
+                return this.xmpp.xmppSend(
+                    new StzaPresenceItem(
+                        member.anonymousJid.toString(),
+                        stanza.attrs.from,
+                        undefined,
+                        PresenceAffiliation.Member,
+                        PresenceRole.Participant,
+                        false,
+                        realJid,
+                    ),
+                ) 
+            })());
         }
 
         // Wait for all presence to be sent first.

--- a/test/mocks/XJSInstance.ts
+++ b/test/mocks/XJSInstance.ts
@@ -11,7 +11,6 @@ export class MockXJSInstance extends EventEmitter {
     public sentPackets: Element[] = [];
     public selfPingResponse: "respond-ok"|"respond-error"|"no-response" = "respond-error";
     public accountUsername!: string;
-    public drainWaits: number = 0;
 
     public xmppAddSentMessage(id: string) {
         this.sentMessageIDs.push(id);
@@ -51,10 +50,5 @@ export class MockXJSInstance extends EventEmitter {
 
     public xmppWriteToStream(msg: Element) {
         this.sentPackets.push(msg);
-    }
-
-    public xmppWaitForDrain(): Promise<void> {
-        this.drainWaits++;
-        return Promise.resolve();
     }
 }

--- a/test/test_autoregistration.ts
+++ b/test/test_autoregistration.ts
@@ -1,25 +1,12 @@
 // tslint:disable: no-any
 import * as Chai from "chai";
 import { AutoRegistration } from "../src/AutoRegistration";
+import { Config } from "../src/Config";
 const expect = Chai.expect;
-
-function createAR() {
-    const bridge = {};
-    const store = {};
-    const purple = {};
-    return new AutoRegistration(
-        {} as any,
-        {},
-        bridge as any,
-        store as any,
-        purple as any,
-    );
-}
 
 describe("AutoRegistration", () => {
     it("generateParameters", () => {
-        const ar = createAR();
-        const params = ar.generateParameters(
+        const params = AutoRegistration.generateParameters(
             {
                 mxid_test: "<T_MXID>:foo",
                 mxid_sane_test: "<T_MXID_SANE>:foo",

--- a/test/xmppjs/test_XJSGateway.ts
+++ b/test/xmppjs/test_XJSGateway.ts
@@ -195,7 +195,6 @@ describe("XJSGateway", () => {
             });
             // 2500 users + 1 self presence
             expect(messages.filter((m) => m.type === "presence")).to.have.lengthOf(2501);
-            expect(mockXmpp.drainWaits).to.equal(2500 / 100);
         });
         it("should reflect a join to all other XMPP users in the room", async () => {
             const room: IGatewayRoom = {


### PR DESCRIPTION
By adding a cache to `AutoRegistration.generateParametersFor` and not blocking on iteration of gateway room members.