### PR TITLE
Don't log pings being sent before they're actually sent

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - run: scripts/changelog-check.sh

--- a/changelog.d/260.bugfix
+++ b/changelog.d/260.bugfix
@@ -1,0 +1,1 @@
+Don't log pings being sent before they're actually sent

--- a/scripts/changelog-check.sh
+++ b/scripts/changelog-check.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+pip3 install towncrier==19.2.0
+python3 -m towncrier.check --compare-with=origin/develop

--- a/src/xmppjs/ServiceHandler.ts
+++ b/src/xmppjs/ServiceHandler.ts
@@ -381,8 +381,8 @@ export class ServiceHandler {
         if (to === this.xmpp.xmppAddress.domain) {
             // Server-To-Server pings
             if (jid(from).domain === from) {
-                log.debug(`S2S ping result sent to ${from}`);
                 await this.xmpp.xmppSend(new StzaIqPing(to, from, id, "result"));
+                log.debug(`S2S ping result sent to ${from}`);
                 return;
             }
             // If the 'from' part is not a domain, this is not a S2S ping.


### PR DESCRIPTION
This should allow us to more accurately investigate the issues with ping responses.