### PR TITLE
Fix not being able to DM users with non-ascii usernames

### DIFF
--- a/changelog.d/271.bugfix
+++ b/changelog.d/271.bugfix
@@ -1,0 +1,1 @@
+Fix not being able to DM users with non-ascii usernames


### PR DESCRIPTION
Remote usernames with multibyte characters in them currently get encoded
into mxids in a way that may result in information loss
(see https://github.com/matrix-org/matrix-appservice-bridge/issues/346).

This makes it impossible to reach some users by MXID alone, so this
makes it lookup the MXID in the user store, which contains the original,
unmangled username.

Fixes GH-268.