### PR TITLE
Include attachment URLs (if present) with purple messages

### DIFF
--- a/changelog.d/290.feature
+++ b/changelog.d/290.feature
@@ -1,0 +1,1 @@
+Include attachment URLs (if present) with libpurple-bridged messages

--- a/src/purple/PurpleAccount.ts
+++ b/src/purple/PurpleAccount.ts
@@ -65,7 +65,13 @@ export class PurpleAccount implements IBifrostAccount {
     }
 
     public sendIM(recipient: string, msg: IBasicProtocolMessage) {
-        messaging.sendIM(this.handle, recipient, msg.body);
+        let body = msg.body;
+
+        if (msg.opts?.attachments) {
+            body += " " + msg.opts.attachments.map(a => a.uri).join(', ');
+        }
+
+        messaging.sendIM(this.handle, recipient, body);
     }
 
     public sendIMTyping(recipient: string, isTyping: boolean) {


### PR DESCRIPTION
We don't have a luxury of using HTML unfortunately, so this is the next
best thing (which shows both the filename and the link).