### PR TITLE
Reword GatewayMUCMembership storage to significantly speed up common operations

### DIFF
--- a/changelog.d/293.misc
+++ b/changelog.d/293.misc
@@ -1,1 +1,1 @@
-Speed up joins for large rooms, preventing them from locking up the process
+Speed up joins for large rooms from XMPP gateways, preventing them from locking up the process

--- a/changelog.d/293.misc
+++ b/changelog.d/293.misc
@@ -1,0 +1,1 @@
+Speed up joins for large rooms, preventing them from locking up the process

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -309,8 +309,6 @@ export class XmppJsGateway implements IGateway {
 
         // Ensure our membership is accurate.
         this.updateMatrixMemberListForRoom(chatName, room, true); // HACK: Always update members for joiners
-        const members = this.members.getMembers(chatName);
-
         // Check if the nick conflicts.
         const existingMember = this.members.getMemberByAnonJid(chatName, stanza.attrs.to);
         if (existingMember) {
@@ -348,10 +346,10 @@ export class XmppJsGateway implements IGateway {
 
         // https://xmpp.org/extensions/xep-0045.html#order
         // 1. membership of others.
-        log.debug(`Emitting membership of other users (${members.length})`);
+        log.debug('Emitting membership of other users');
         // Ensure we chunk this
         const allMembershipPromises: Promise<unknown>[] = [];
-        for (const member of members) {
+        for (const member of this.members.getMembers(chatName)) {
             if (member.anonymousJid.toString() === stanza.attrs.to) {
                 continue;
             }


### PR DESCRIPTION
The biggest winners here are addMatrixMember() and removeMatrixMember(),
which were a hotpath of updateMatrixMemberListForRoom, called upon xmpp users
joining matrix rooms, which used to lock up the process completely for
large rooms.

On a local test with a 3000-person room, the joins went down from ~500ms
to ~200 and then ~50 once the caches warm up. The remaining time *seems*
to be mostly spent on IO (sending actual XMPP presence updates), and the
offending code disappears completely from a profiler output – hopefully
meaning that the bridge will have ample time to deal with other tasks
instead of locking up completely like it used to.

There are some remaining bits that iterate on indexable member lists,
though they don't seem to be a measurable performance problem for now,
so I left them as they are – but easily identifyable with the menacing
Array.from().