### PR TITLE
config: correct typo to ensure consistency between example and code

### DIFF
--- a/changelog.d/302.bugfix
+++ b/changelog.d/302.bugfix
@@ -1,0 +1,1 @@
+correct typo of pluginDir in sample config/doc

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -50,7 +50,7 @@ purple:
   # # Should the backend output extra logging.
   #   debugEnabled: false
   # # Where are the plugin libraries stored.
-  #   pluginsDir: "/usr/lib/purple-2"
+  #   pluginDir: "/usr/lib/purple-2"
   # # Where should purple account data be stored.
   #   dataDir: "./purple-data"
   # # Should only one plugin be enabled (to simplify userIds / commands).


### PR DESCRIPTION
There is a typo in the sample config file, reporting the pluginDir option as pluginsDir;
The code uses pluginDir instead (see: https://github.com/matrix-org/matrix-bifrost/blob/e222ccd5706bcb37d5584ba1d6a85d823cc38ff2/src/purple/PurpleInstance.ts#L19 ) and isn't documented anywhere else, so it might be a nice idea to correct this typo.