### PR TITLE
Fix possible undefined setJoinPropertiesForRoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+ 0.4.0 (2022-11-16)
+===================
+
+Bugfixes
+--------
+
+- Fix crash on startup due to logging / metrics failures. ([\#321](https://github.com/matrix-org/matrix-bifrost/issues/321))
+
+
 0.4.0 (2022-11-07)
 ===================
 

--- a/changelog.d/321.bugfix
+++ b/changelog.d/321.bugfix
@@ -1,1 +1,0 @@
-Fix crash on startup due to logging / metrics failures.

--- a/changelog.d/323.bugfix
+++ b/changelog.d/323.bugfix
@@ -1,0 +1,1 @@
+Fix being unable to join XMPP rooms via Matrix aliases.

--- a/changelog.d/323.bugfix
+++ b/changelog.d/323.bugfix
@@ -1,1 +1,1 @@
-Fix being unable to join XMPP rooms via Matrix aliases.
+Fix being unable to join XMPP MUCs via Matrix room aliases.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-bifrost",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Multi protocol bridging for Matrix.",
   "engines": {
     "node": ">=16"

--- a/src/MatrixEventHandler.ts
+++ b/src/MatrixEventHandler.ts
@@ -842,7 +842,7 @@ E.g. \`${command} ${acct.protocol.id}\` ${required.join(" ")} ${optional.join(" 
     private async joinOrDefer(acct: IBifrostAccount, name: string, properties: IChatJoinProperties): Promise<void> {
         if (acct.connected) {
             await acct.joinChat(properties);
-            acct.setJoinPropertiesForRoom(name, properties);
+            acct.setJoinPropertiesForRoom?.(name, properties);
             return;
         }
         log.debug("Account is not connected, deferring join until connected");

--- a/src/RoomSync.ts
+++ b/src/RoomSync.ts
@@ -183,7 +183,7 @@ export class RoomSync {
                 if (membership.membership === "join") {
                     log.info(`${i}/${reconsToMake} JOIN ${remoteId} -> ${membership.room_name}`);
                     await acct.joinChat(membership.params, this.bifrost, JOINLEAVE_TIMEOUT, false);
-                    acct.setJoinPropertiesForRoom && acct.setJoinPropertiesForRoom(membership.room_name, membership.params);
+                    acct.setJoinPropertiesForRoom?.(membership.room_name, membership.params);
                 } else {
                     log.info(`${i}/${reconsToMake} LEAVE ${remoteId} -> ${membership.room_name}`);
                     await acct!.rejectChat(membership.params);


### PR DESCRIPTION
Should fix:

```
ERROR 13:13:14:279 [MatrixEventHandler] Couldn't send message to chat: TypeError: acct.setJoinPropertiesForRoom is not a function
    at MatrixEventHandler.joinOrDefer (/app/src/MatrixEventHandler.ts:845:18)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at MatrixEventHandler.handleGroupMessage (/app/src/MatrixEventHandler.ts:640:17)
    at MatrixEventHandler.onEvent (/app/src/MatrixEventHandler.ts:237:13)
```