### PR TITLE
Fix nedb's usage of node:util for Node 24

### DIFF
--- a/changelog.d/374.bugfix
+++ b/changelog.d/374.bugfix
@@ -1,0 +1,1 @@
+Deprecate the "nedb" datastore engine, and fix known crash when using it in Node 24.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -28,7 +28,7 @@ roomRules: []
 #   action: "deny"
 
 datastore:
-  # The datastore engine to use, either "nedb" or "postgres"
+  # The datastore engine to use, either "nedb" (deprecated) or "postgres"
   engine: "postgres"
 
   # For NeDB:

--- a/src/store/NeDBStore.ts
+++ b/src/store/NeDBStore.ts
@@ -19,6 +19,13 @@ export class NeDBStore implements IStore {
     private userLock: Map<string, Promise<void>>;
 
     constructor(bridge: Bridge) {
+        log.warn("NeDB-based stores are now deprecated.");
+        // required fix for nedb being incredibly outdated
+        if (parseInt(process.versions.node.split(".")[0]) >= 24) {
+            const util = require("node:util"); // eslint-disable-line @typescript-eslint/no-var-requires
+            util.isDate = util.types.isDate;
+            util.isRegExp = util.types.isRegExp;
+        }
         const roomStore = bridge.getRoomStore();
         const userStore = bridge.getUserStore();
         if (!roomStore || !userStore) {


### PR DESCRIPTION
Monkey patch node:util to include deprecated functions removed as of Node 24 but still needed by nedb.

Also print a deprecation warning when using the nedb store.

---

This opts to deprecate nedb support rather than just drop it entirely because the unit tests still rely on it.  Dropping it should be done only after unit tests switch to some other store (preferably a file-based one, lest tests have to set up a PostgreSQL instance).