### PR TITLE
Answer disco#info on gateway room JIDs with the room's name

### DIFF
--- a/changelog.d/378.bugfix
+++ b/changelog.d/378.bugfix
@@ -1,0 +1,1 @@
+Gateway rooms now answer disco#info with the room's name instead of identifying as matrix-bifrost.

--- a/changelog.d/380.feature
+++ b/changelog.d/380.feature
@@ -1,0 +1,1 @@
+Matrix room renames now propagate to XMPP room discovery.

--- a/spec/gateway-room-discovery.spec.ts
+++ b/spec/gateway-room-discovery.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect } from "vitest";
+import { xml } from "@xmpp/client";
+import { test as baseTest } from "./util/fixtures";
+import { XMPP_COMPONENT_DOMAIN } from "./util/containers/prosody";
+import type { BifrostTestEnv, BifrostTestEnvOpts } from "./util/bifrost-env";
+import type { E2ETestMatrixClient } from "./util/e2e-test";
+
+// Gateway room discovery (ServiceHandler's disco#items/disco#info handling for gateway room
+// JIDs) only runs when portals.enableGateway is set - see XJSInstance#preStart.
+const test = baseTest.override("testEnvOpts", {
+    config: {
+        portals: { enableGateway: true },
+    },
+} as BifrostTestEnvOpts);
+
+async function createPublicRoom(
+    testEnv: BifrostTestEnv, alice: E2ETestMatrixClient, aliasLocalpart: string, name: string,
+): Promise<string> {
+    const roomId = await alice.createRoom({
+        visibility: "public",
+        preset: "public_chat",
+        name,
+        room_alias_name: aliasLocalpart,
+    });
+    const alias = `#${aliasLocalpart}:${testEnv.serverName}`;
+    // createRoom's room_alias_name maps the alias but does not set canonical_alias itself.
+    await alice.sendStateEvent(roomId, "m.room.canonical_alias", "", { alias });
+    return alias;
+}
+
+// Mirrors ServiceHandler#createJIDFromAlias, so tests can address a gateway room's JID directly.
+function roomJid(alias: string): string {
+    const [local, server] = alias.replace(/^#/, "").split(":");
+    return `#${local}#${server}@${XMPP_COMPONENT_DOMAIN}`;
+}
+
+describe("XMPP gateway", () => {
+    test("lists public Matrix rooms via disco#items", async ({ testEnv, alice }) => {
+        const alias = await createPublicRoom(testEnv, alice, "disco-items-room", "Disco Items Room");
+
+        const response = await testEnv.xmpp.iqCaller.request(xml(
+            "iq",
+            { type: "get", to: XMPP_COMPONENT_DOMAIN, from: testEnv.xmpp.jid?.toString() },
+            xml("query", { xmlns: "http://jabber.org/protocol/disco#items" }),
+        ));
+
+        const items = response.getChild("query", "http://jabber.org/protocol/disco#items")?.getChildren("item") ?? [];
+        const item = items.find((i) => i.attrs.jid === roomJid(alias));
+        expect(item).toBeDefined();
+        expect(item?.attrs.name).toEqual("Disco Items Room");
+    });
+
+    test("returns search fields for a jabber:iq:search 'get' request", async ({ testEnv }) => {
+        const response = await testEnv.xmpp.iqCaller.request(xml(
+            "iq",
+            { type: "get", to: XMPP_COMPONENT_DOMAIN, from: testEnv.xmpp.jid?.toString() },
+            xml("query", { xmlns: "jabber:iq:search" }),
+        ));
+
+        const query = response.getChild("query", "jabber:iq:search");
+        expect(query?.getChild("instructions")).toBeDefined();
+        expect(query?.getChild("Term")).toBeDefined();
+        expect(query?.getChild("Homeserver")).toBeDefined();
+    });
+
+    test("finds a public room by search term via jabber:iq:search", async ({ testEnv, alice }) => {
+        const alias = await createPublicRoom(testEnv, alice, "search-findme-room", "Findable Room");
+
+        const response = await testEnv.xmpp.iqCaller.request(xml(
+            "iq",
+            { type: "set", to: XMPP_COMPONENT_DOMAIN, from: testEnv.xmpp.jid?.toString() },
+            xml("query", { xmlns: "jabber:iq:search" }, xml("Term", {}, "Findable Room")),
+        ));
+
+        const items = response.getChild("query", "jabber:iq:search")?.getChildren("item") ?? [];
+        expect(items.some((i) => i.attrs.jid === roomJid(alias))).toEqual(true);
+    });
+
+    test("returns disco#info for a gateway room JID, naming it after the Matrix room", async ({ testEnv, alice }) => {
+        const alias = await createPublicRoom(testEnv, alice, "disco-info-room", "Disco Info Room");
+
+        const response = await testEnv.xmpp.iqCaller.request(xml(
+            "iq",
+            { type: "get", to: roomJid(alias), from: testEnv.xmpp.jid?.toString() },
+            xml("query", { xmlns: "http://jabber.org/protocol/disco#info" }),
+        ));
+
+        const identities = response.getChild("query", "http://jabber.org/protocol/disco#info")
+            ?.getChildren("identity") ?? [];
+        const conference = identities.find((i) => i.attrs.category === "conference");
+        const gateway = identities.find((i) => i.attrs.category === "gateway");
+        expect(conference?.attrs.name).toEqual("Disco Info Room");
+        expect(gateway?.attrs.name).toEqual(alias);
+    });
+
+    test("returns item-not-found for a gateway room JID with no matching Matrix alias", async ({ testEnv }) => {
+        const to = roomJid(`#does-not-exist:${testEnv.serverName}`);
+
+        await expect(testEnv.xmpp.iqCaller.request(xml(
+            "iq",
+            { type: "get", to, from: testEnv.xmpp.jid?.toString() },
+            xml("query", { xmlns: "http://jabber.org/protocol/disco#info" }),
+        ))).rejects.toMatchObject({ condition: "item-not-found" });
+    });
+});

--- a/spec/util/containers/synapse.ts
+++ b/spec/util/containers/synapse.ts
@@ -62,6 +62,9 @@ export class SynapseContainer extends GenericContainer {
             registration_shared_secret: this.registrationSecret,
             app_service_config_files: Array.from(this.appserviceFiles),
             federation_ip_range_blacklist: [],
+            // Synapse denies publishing rooms to the room directory by default.
+            // Tests that create public/discoverable rooms need this.
+            room_list_publication_rules: [{ action: "allow" }],
             database: { name: "sqlite3", args: { database: ":memory:" } },
             rc_federation: { window_size: 1000, sleep_limit: 10, sleep_delay: 500, reject_limit: 99999, concurrent: 3 },
             rc_message: rc,

--- a/src/GatewayHandler.ts
+++ b/src/GatewayHandler.ts
@@ -73,7 +73,7 @@ export class GatewayHandler {
             ));
             const room: IGatewayRoom = {
                 name: typeof nameEv?.content?.name === "string" ? nameEv.content.name : "",
-                topic: nameEv?.content?.topic === "string" ? nameEv.content.topic : "",
+                topic: typeof topicEv?.content?.topic === "string" ? topicEv.content.topic : "",
                 roomId,
                 membership,
             };
@@ -248,11 +248,56 @@ export class GatewayHandler {
         try {
             const roomId = await this.bridge.getIntent().matrixClient.resolveRoom(ev.roomAlias);
             log.info(`Found ${roomId}`);
-            ev.result(null, roomId);
+            ev.result(null, { roomId, name: await this.getRoomName(roomId, ev.roomAlias) });
         } catch (ex) {
             log.warn("Room not found:", ex);
             ev.result(Error("Room not found"));
         }
+    }
+
+    /**
+     * Best-effort lookup of a room's m.room.name, so XMPP-side discovery (disco#info on the
+     * gateway MUC JID) can present the room's human name rather than the bridge's own identity.
+     * Reads room state directly when the bridge bot is a member (all bifrost-created portals),
+     * falling back to the room summary API (MSC3266) for publicly-joinable rooms it isn't in.
+     */
+    private async getRoomName(roomId: string, roomAlias: string): Promise<string|undefined> {
+        const client = this.bridge.getIntent().matrixClient;
+        try {
+            const content = await client.getRoomStateEvent(roomId, "m.room.name", "");
+            if (typeof content?.name === "string" && content.name) {
+                return content.name;
+            }
+        } catch (ex) {
+            log.debug(`Could not read m.room.name of ${roomId} directly: ${ex}`);
+        }
+        try {
+            const summary = await client.doRequest(
+                "GET", `/_matrix/client/unstable/im.nheko.summary/rooms/${encodeURIComponent(roomId)}/summary`,
+            );
+            if (typeof summary?.name === "string" && summary.name) {
+                return summary.name;
+            }
+        } catch (ex) {
+            log.debug(`Could not fetch room summary of ${roomId}: ${ex}`);
+        }
+        // Directory-listed rooms expose their name via the public-rooms search even when the
+        // bridge has no user in the room — exactly the browse-before-joining case (and gateway
+        // joins require publicly-joinable rooms, which in practice are directory-listed).
+        try {
+            const term = roomAlias.split(":")[0].replace(/^#/, "");
+            const res = await client.doRequest("POST", "/_matrix/client/v3/publicRooms", null, {
+                limit: 50,
+                filter: { generic_search_term: term },
+            });
+            const entry = res?.chunk?.find((r: {room_id: string}) => r.room_id === roomId);
+            if (typeof entry?.name === "string" && entry.name) {
+                return entry.name;
+            }
+        } catch (ex) {
+            log.debug(`Could not find ${roomId} in the public rooms directory: ${ex}`);
+        }
+        return undefined;
     }
 
     private async handlePublicRooms(ev: IGatewayPublicRoomsQuery) {

--- a/src/GatewayHandler.ts
+++ b/src/GatewayHandler.ts
@@ -262,7 +262,7 @@ export class GatewayHandler {
      * Best-effort lookup of a room's m.room.name, so XMPP-side discovery (disco#info on the
      * gateway MUC JID) can present the room's human name rather than the bridge's own identity.
      * Reads room state directly when the bridge bot is a member (all bifrost-created portals),
-     * falling back to the room summary API (MSC3266) for publicly-joinable rooms it isn't in.
+     * falling back to the room summary API, and then finally the public rooms list.
      */
     private async getRoomName(roomId: string, roomAlias: string): Promise<string|undefined> {
         const client = this.bridge.getIntent().matrixClient;
@@ -276,7 +276,7 @@ export class GatewayHandler {
         }
         try {
             const summary = await client.doRequest(
-                "GET", `/_matrix/client/unstable/im.nheko.summary/rooms/${encodeURIComponent(roomId)}/summary`,
+                "GET", `/_matrix/client/v1/room_summary/${encodeURIComponent(roomId)}`,
             );
             if (typeof summary?.name === "string" && summary.name) {
                 return summary.name;

--- a/src/GatewayHandler.ts
+++ b/src/GatewayHandler.ts
@@ -108,6 +108,9 @@ export class GatewayHandler {
             log.info("Handing room name change for gateway");
             room.name = ev.content.name;
             this.purple.gateway.sendStateChange(chatName, sender, "name", room);
+            // Also refresh the discovery cache, so XMPP room lists (per-room disco#info)
+            // pick the rename up immediately rather than after the cache TTL.
+            this.purple.gateway.updateRoomName(room.roomId, room.name);
         } else if (ev.type === "m.room.topic") {
             log.info("Handing room topic change for gateway");
             room.topic = ev.content.topic;

--- a/src/bifrost/Events.ts
+++ b/src/bifrost/Events.ts
@@ -84,8 +84,14 @@ export interface IGatewayRequest {
     result: (err: Error|null, res?: any) => void;
 }
 
+export interface IGatewayRoomQueryResult {
+    roomId: string;
+    // The room's m.room.name, if it has one and it is readable by the bridge.
+    name?: string;
+}
+
 export interface IGatewayRoomQuery extends IGatewayRequest {
-    result: (err: Error|null, res?: string) => void;
+    result: (err: Error|null, res?: IGatewayRoomQueryResult) => void;
 }
 
 export interface IGatewayPublicRoomsQuery extends IGatewayRequest {

--- a/src/bifrost/Gateway.ts
+++ b/src/bifrost/Gateway.ts
@@ -19,6 +19,11 @@ export interface IGateway extends IProfileProvider {
     initialMembershipSync(chatName: string, room: IGatewayRoom, remoteGhosts: BifrostRemoteUser[]): void;
     getMxidForRemote(sender: string): string;
     memberInRoom(chatName: string, matrixId: string): boolean;
+    /**
+     * The Matrix room was renamed: refresh anything presenting the room's name to the remote
+     * network (e.g. cached disco#info identities), so room lists pick the new name up live.
+     */
+    updateRoomName(roomId: string, name?: string): void;
 }
 
 export interface IGatewayRoom {

--- a/src/xmppjs/ServiceHandler.ts
+++ b/src/xmppjs/ServiceHandler.ts
@@ -2,8 +2,7 @@ import { Element, x } from "@xmpp/xml";
 import { XmppJsInstance } from "./XJSInstance";
 import { jid, JID } from "@xmpp/jid";
 import { getBridgeVersion, Intent, Logger } from "matrix-appservice-bridge";
-import { IGatewayRoom } from "../bifrost/Gateway";
-import { IGatewayRoomQuery, IGatewayPublicRoomsQuery } from "../bifrost/Events";
+import { IGatewayRoomQuery, IGatewayRoomQueryResult, IGatewayPublicRoomsQuery } from "../bifrost/Events";
 import { StzaIqDiscoInfo, StzaIqPing, StzaIqDiscoItems, StzaIqSearchFields, SztaIqError, StzaIqPingError, NODE_NAME } from "./Stanzas";
 import { IPublicRoomsResponse } from "../MatrixTypes";
 import { IConfigBridge } from "../Config";
@@ -15,7 +14,7 @@ const MAX_AVATARS = 1024;
 
 export class ServiceHandler {
     private avatarCache: Map<string, {data: Buffer, type: string}>;
-    private existingAliases: Map<string, string>; /* alias -> room_id */
+    private existingAliases: Map<string, IGatewayRoomQueryResult>; /* alias -> {room_id, name} */
     private readonly serverDiscoInfo: StzaIqDiscoInfo;
     private readonly userDiscoInfo: StzaIqDiscoInfo;
     public readonly userDiscoHash: string;
@@ -78,6 +77,12 @@ export class ServiceHandler {
         if (isDisco) {
             log.debug(`Disco info request from ${from} -> ${to} (${id})`);
             if (local) {
+                // A gateway room JID (#local#server@component) must answer as a CONFERENCE with
+                // the room's name — not as the bridge's own client identity, which made every
+                // Matrix room show up as "matrix-bifrost" in XMPP room lists.
+                if (this.xmpp.gateway && this.parseAliasFromJID(jid(to))) {
+                    return this.handleRoomDiscovery(to, from, id);
+                }
                 return this.sendUserDiscoInfo(from, to, id);
             } else {
                 return this.handleServerDiscoInfo(from, to, id);
@@ -105,9 +110,6 @@ export class ServiceHandler {
                 return this.handleDiscoItems(from, to, id, stanza.attrs.type, searchQuery as Element);
             }
 
-            if (stanza.getChildByAttr("xmlns", "http://jabber.org/protocol/disco#info") && local) {
-                return this.handleRoomDiscovery(to, from, id);
-            }
         }
 
         return this.xmpp.xmppWriteToStream(x("iq", {
@@ -259,7 +261,7 @@ export class ServiceHandler {
         await this.xmpp.xmppSend(response);
     }
 
-    private queryRoom(roomAlias: string): Promise<string|IGatewayRoom> {
+    private queryRoom(roomAlias: string): Promise<IGatewayRoomQueryResult> {
         return new Promise((resolve, reject) => {
             this.xmpp.emit("gateway-queryroom", {
                 roomAlias,
@@ -281,12 +283,14 @@ export class ServiceHandler {
                 throw Error("Not a valid alias");
             }
             log.debug(`Running room discovery for ${toStr}`);
-            let roomId = this.existingAliases.get(alias);
-            if (!roomId) {
-                roomId = await this.queryRoom(alias) as string;
-                this.existingAliases.set(alias, roomId);
+            // The alias->roomId mapping is stable, but the name can change: re-query when we
+            // have no name cached so renames eventually propagate.
+            let room = this.existingAliases.get(alias);
+            if (!room || !room.name) {
+                room = await this.queryRoom(alias);
+                this.existingAliases.set(alias, room);
             }
-            log.info(`Response for alias request ${toStr} (${alias}) -> ${roomId}`);
+            log.info(`Response for alias request ${toStr} (${alias}) -> ${room.roomId}`);
             const discoInfo = new StzaIqDiscoInfo(toStr, from, id);
             discoInfo.feature.add(XMPPFeatures.DiscoInfo);
             discoInfo.feature.add(XMPPFeatures.Muc);
@@ -294,7 +298,9 @@ export class ServiceHandler {
             discoInfo.feature.add(XMPPFeatures.XHTMLIM);
             discoInfo.identity.add({
                 category: "conference",
-                name: alias,
+                // The room's human name, so XMPP room lists show something meaningful; the
+                // alias is still shown via the JID itself.
+                name: room.name || alias,
                 type: "text",
             });
             discoInfo.identity.add({

--- a/src/xmppjs/ServiceHandler.ts
+++ b/src/xmppjs/ServiceHandler.ts
@@ -11,10 +11,20 @@ import { XMPPFeatures } from "./XMPPConstants";
 const log = new Logger("ServiceHandler");
 
 const MAX_AVATARS = 1024;
+// How long a gateway room's cached name is trusted before disco re-queries it. Only a
+// fallback for rooms the bridge has no user in - renames in bridged rooms are pushed
+// straight into the cache (updateCachedRoomName).
+const ROOM_NAME_CACHE_MS = 5 * 60 * 1000;
 
 export class ServiceHandler {
     private avatarCache: Map<string, {data: Buffer, type: string}>;
-    private existingAliases: Map<string, IGatewayRoomQueryResult>; /* alias -> {room_id, name} */
+    /**
+     * alias -> {room_id, name} for gateway room discovery. The alias->roomId mapping is
+     * stable; the NAME is kept fresh two ways: pushed updates via updateCachedRoomName (rooms
+     * the bridge has a user in, so renames propagate live) and a TTL re-query (rooms nobody
+     * has joined yet, where no Matrix events reach the bridge).
+     */
+    private existingAliases: Map<string, IGatewayRoomQueryResult & {fetchedAt: number}>;
     private readonly serverDiscoInfo: StzaIqDiscoInfo;
     private readonly userDiscoInfo: StzaIqDiscoInfo;
     public readonly userDiscoHash: string;
@@ -41,6 +51,16 @@ export class ServiceHandler {
         this.userDiscoInfo.feature.add(XMPPFeatures.ChatStates);
         this.userDiscoHash = this.userDiscoInfo.hash;
         this.userDiscoInfo.node = `${NODE_NAME}#${this.userDiscoHash}`;
+    }
+
+    /** Push a Matrix room rename into the discovery cache (see existingAliases). */
+    public updateCachedRoomName(roomId: string, name?: string): void {
+        for (const entry of this.existingAliases.values()) {
+            if (entry.roomId === roomId) {
+                entry.name = name;
+                entry.fetchedAt = Date.now();
+            }
+        }
     }
 
     public parseAliasFromJID(to: JID): string|null {
@@ -283,11 +303,9 @@ export class ServiceHandler {
                 throw Error("Not a valid alias");
             }
             log.debug(`Running room discovery for ${toStr}`);
-            // The alias->roomId mapping is stable, but the name can change: re-query when we
-            // have no name cached so renames eventually propagate.
             let room = this.existingAliases.get(alias);
-            if (!room || !room.name) {
-                room = await this.queryRoom(alias);
+            if (!room || !room.name || Date.now() - room.fetchedAt > ROOM_NAME_CACHE_MS) {
+                room = { ...await this.queryRoom(alias), fetchedAt: Date.now() };
                 this.existingAliases.set(alias, room);
             }
             log.info(`Response for alias request ${toStr} (${alias}) -> ${room.roomId}`);

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -115,6 +115,10 @@ export class XmppJsGateway implements IGateway {
         return !!this.members.getXmppMemberByMatrixId(chatName, matrixId);
     }
 
+    public updateRoomName(roomId: string, name?: string) {
+        this.xmpp.serviceHandler.updateCachedRoomName(roomId, name);
+    }
+
     public isJIDInMuc(chatName: string, j: JID) {
         return !!this.members.getXmppMemberByDevice(chatName, j);
     }


### PR DESCRIPTION
Per-room disco#info on gateway JIDs was shadowed by the generic user-disco branch, so every room advertised itself as `client/bridge: matrix-bifrost`. Route gateway room JIDs to `handleRoomDiscovery` and answer as a `conference` with the room's actual name (bot state read, with MSC3266 summary and `/publicRooms` search as fallbacks for rooms the bot isn't in). Also fixes `getVirtualRoom` reading the topic off the name event.

this PR was generated by Fable but reviewed by hand
