### PR TITLE
Name portal rooms after the remote room's name

### DIFF
--- a/changelog.d/379.feature
+++ b/changelog.d/379.feature
@@ -1,0 +1,1 @@
+Portal rooms are now named after the remote room's name.

--- a/spec/muc-portal.spec.ts
+++ b/spec/muc-portal.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect } from "vitest";
+import { xml } from "@xmpp/client";
+import { test as baseTest } from "./util/fixtures";
+import { XMPP_MUC_DOMAIN } from "./util/containers/prosody";
+
+const MUC_ROOM_LOCALPART = "e2eroom";
+const MUC_ROOM_NAME = "E2E Test Room";
+const MUC_ROOM_JID = `${MUC_ROOM_LOCALPART}@${XMPP_MUC_DOMAIN}`;
+
+const test = baseTest.override("testEnvOpts", () => ({
+    config: {
+        portals: {
+            aliases: {
+                "^_bifrost_(.+)$": {
+                    protocol: "xmpp-js",
+                    properties: {
+                        room: "regex:1",
+                        server: XMPP_MUC_DOMAIN,
+                    },
+                },
+            },
+        },
+    },
+}));
+
+describe("XMPP MUC portal rooms", () => {
+    test("names the Matrix portal room after the MUC's disco#info identity name", async ({ testEnv, alice }) => {
+        // Join the MUC as its first occupant (making us the owner), then set the room's
+        // human-readable name via the XEP-0045 configuration form. That name ends up in
+        // the MUC's disco#info identity, which the bridge reads to name the portal room.
+        await testEnv.xmpp.send(xml(
+            "presence",
+            { to: `${MUC_ROOM_JID}/owner` },
+            xml("x", { xmlns: "http://jabber.org/protocol/muc" }),
+        ));
+        await testEnv.xmpp.iqCaller.request(xml(
+            "iq",
+            { type: "set", to: MUC_ROOM_JID },
+            xml(
+                "query",
+                { xmlns: "http://jabber.org/protocol/muc#owner" },
+                xml(
+                    "x",
+                    { xmlns: "jabber:x:data", type: "submit" },
+                    xml(
+                        "field",
+                        { var: "FORM_TYPE", type: "hidden" },
+                        xml("value", {}, "http://jabber.org/protocol/muc#roomconfig"),
+                    ),
+                    xml(
+                        "field",
+                        { var: "muc#roomconfig_roomname" },
+                        xml("value", {}, MUC_ROOM_NAME),
+                    ),
+                ),
+            ),
+        ));
+
+        const roomName = alice.waitForRoomEvent({
+            eventType: "m.room.name", sender: testEnv.botMxid, stateKey: "",
+        });
+
+        await alice.joinRoom(`#_bifrost_${MUC_ROOM_LOCALPART}:${testEnv.serverName}`);
+
+        const { data } = await roomName;
+        expect((data.content as { name: string }).name).toEqual(MUC_ROOM_NAME);
+    });
+});

--- a/spec/util/containers/prosody.ts
+++ b/spec/util/containers/prosody.ts
@@ -19,6 +19,8 @@ export const XMPP_TEST_PASSWORD = "xmpp_password";
 // Fixed so tests can compute the expected ghost mxid (XJSInstance#getMxIdForProtocol
 // puts the resource first in the localpart) deterministically.
 export const XMPP_TEST_RESOURCE = "testinstance";
+// A MUC component, for tests that bridge XMPP group chats into Matrix portal rooms.
+export const XMPP_MUC_DOMAIN = "conference.xmpp.localhost";
 
 const PROSODY_C2S_PORT = 5222;
 const PROSODY_COMPONENT_PORT = 5347;
@@ -71,6 +73,9 @@ VirtualHost "${XMPP_C2S_DOMAIN}"
 
 Component "${XMPP_COMPONENT_DOMAIN}"
     component_secret = "${XMPP_COMPONENT_SECRET}"
+
+Component "${XMPP_MUC_DOMAIN}" "muc"
+    name = "Chatrooms"
 `;
 }
 

--- a/src/MatrixEventHandler.ts
+++ b/src/MatrixEventHandler.ts
@@ -77,11 +77,15 @@ export class MatrixEventHandler {
             return null;
         }
 
+        // Name the portal after the remote group's human name (e.g. the MUC's XEP-0045
+        // disco#info identity name), so clients don't fall back to the raw bridge alias.
+        const groupName = await this.purple.getGroupName?.(properties, protocol);
         log.info(`Creating new room for ${protocol.id} with`, properties);
         this.pendingRoomAliases.set(alias, {protocol, props: properties});
         return {
             creationOpts: {
                 room_alias_name: aliasLocalpart,
+                ...(groupName ? { name: groupName } : {}),
                 initial_state: [
                     {
                         type: "m.room.join_rules",

--- a/src/bifrost/Instance.ts
+++ b/src/bifrost/Instance.ts
@@ -33,6 +33,11 @@ export interface IBifrostInstance extends EventEmitter {
     getNickForChat?(conv: any): string;
     getUsernameFromMxid(mxid: string, prefix: string): {username: string, protocol: BifrostProtocol};
     checkGroupExists(properties: IChatJoinProperties, protocol: BifrostProtocol): Promise<boolean>;
+    /**
+     * A human-readable name for the remote group, if the backend can discover one cheaply
+     * (e.g. from data already fetched by checkGroupExists). Used to name portal rooms.
+     */
+    getGroupName?(properties: IChatJoinProperties, protocol: BifrostProtocol): Promise<string|undefined>;
     on(name: string, cb: (ev: IEventBody) => void);
     on(
         name: "account-connection-error"|"account-signed-on"|"account-signed-off",

--- a/src/xmppjs/XJSInstance.ts
+++ b/src/xmppjs/XJSInstance.ts
@@ -77,6 +77,8 @@ export class XmppJsInstance extends EventEmitter implements IBifrostInstance {
     private activeMUCUsers = new Set<string>();
     private lastMessageInMUC = new Map<string, {originIsMatrix: boolean, id: string}>();
     private jingleHandler?: JingleHandler;
+    // MUC JID -> human name from the disco#info identity, filled by checkGroupExists.
+    private groupNames = new Map<string, string>();
     constructor(private config: Config, private readonly bridge: Bridge) {
         super();
         this.serviceHandler = new ServiceHandler(this, this.config.bridge);
@@ -574,6 +576,10 @@ export class XmppJsInstance extends EventEmitter implements IBifrostInstance {
         Metrics.requestOutcome(true, Date.now() - startedAt, "success");
     }
 
+    public async getGroupName(properties: IChatJoinProperties): Promise<string|undefined> {
+        return this.groupNames.get(`${properties.room}@${properties.server}`);
+    }
+
     public async checkGroupExists(properties: IChatJoinProperties) {
         const props = {
             room: properties.room as string,
@@ -591,7 +597,15 @@ export class XmppJsInstance extends EventEmitter implements IBifrostInstance {
         try {
             const result = await this.sendIq(new StzaIqDiscoInfo(this.myAddress.toString(), to, id, "get"));
             log.debug(`Found ${to}`);
-            const isMuc = result.getChild("query")?.getChildByAttr("var", "http://jabber.org/protocol/muc");
+            const query = result.getChild("query");
+            const isMuc = query?.getChildByAttr("var", "http://jabber.org/protocol/muc");
+            // The disco#info identity carries the MUC's human name (XEP-0045); remember it so
+            // getGroupName can hand it to the portal room creation without a second roundtrip.
+            const identityName = query?.getChildren("identity")
+                ?.find((i) => i.getAttr("category") === "conference")?.getAttr("name");
+            if (identityName) {
+                this.groupNames.set(to, identityName);
+            }
             return !!isMuc;
         } catch (ex) {
             // TODO: Factor this out, error parsing would be useful.


### PR DESCRIPTION
Portal rooms were created with no `m.room.name`, leaving clients to fall back to the bridge alias or member names. Cache the MUC's disco#info identity name during `checkGroupExists` and pass it as `creationOpts.name` via a new optional `IBifrostInstance.getGroupName`.

this PR was generated by Fable but reviewed by hand
