### PR TITLE
Propagate live Matrix room renames to XMPP room discovery

### DIFF
--- a/changelog.d/380.feature
+++ b/changelog.d/380.feature
@@ -1,0 +1,1 @@
+Matrix room renames now propagate to XMPP room discovery.

--- a/src/GatewayHandler.ts
+++ b/src/GatewayHandler.ts
@@ -108,6 +108,9 @@ export class GatewayHandler {
             log.info("Handing room name change for gateway");
             room.name = ev.content.name;
             this.purple.gateway.sendStateChange(chatName, sender, "name", room);
+            // Also refresh the discovery cache, so XMPP room lists (per-room disco#info)
+            // pick the rename up immediately rather than after the cache TTL.
+            this.purple.gateway.updateRoomName(room.roomId, room.name);
         } else if (ev.type === "m.room.topic") {
             log.info("Handing room topic change for gateway");
             room.topic = ev.content.topic;

--- a/src/bifrost/Gateway.ts
+++ b/src/bifrost/Gateway.ts
@@ -19,6 +19,11 @@ export interface IGateway extends IProfileProvider {
     initialMembershipSync(chatName: string, room: IGatewayRoom, remoteGhosts: BifrostRemoteUser[]): void;
     getMxidForRemote(sender: string): string;
     memberInRoom(chatName: string, matrixId: string): boolean;
+    /**
+     * The Matrix room was renamed: refresh anything presenting the room's name to the remote
+     * network (e.g. cached disco#info identities), so room lists pick the new name up live.
+     */
+    updateRoomName(roomId: string, name?: string): void;
 }
 
 export interface IGatewayRoom {

--- a/src/xmppjs/ServiceHandler.ts
+++ b/src/xmppjs/ServiceHandler.ts
@@ -11,10 +11,20 @@ import { XMPPFeatures } from "./XMPPConstants";
 const log = new Logger("ServiceHandler");
 
 const MAX_AVATARS = 1024;
+// How long a gateway room's cached name is trusted before disco re-queries it. Only a
+// fallback for rooms the bridge has no user in - renames in bridged rooms are pushed
+// straight into the cache (updateCachedRoomName).
+const ROOM_NAME_CACHE_MS = 5 * 60 * 1000;
 
 export class ServiceHandler {
     private avatarCache: Map<string, {data: Buffer, type: string}>;
-    private existingAliases: Map<string, IGatewayRoomQueryResult>; /* alias -> {room_id, name} */
+    /**
+     * alias -> {room_id, name} for gateway room discovery. The alias->roomId mapping is
+     * stable; the NAME is kept fresh two ways: pushed updates via updateCachedRoomName (rooms
+     * the bridge has a user in, so renames propagate live) and a TTL re-query (rooms nobody
+     * has joined yet, where no Matrix events reach the bridge).
+     */
+    private existingAliases: Map<string, IGatewayRoomQueryResult & {fetchedAt: number}>;
     private readonly serverDiscoInfo: StzaIqDiscoInfo;
     private readonly userDiscoInfo: StzaIqDiscoInfo;
     public readonly userDiscoHash: string;
@@ -41,6 +51,16 @@ export class ServiceHandler {
         this.userDiscoInfo.feature.add(XMPPFeatures.ChatStates);
         this.userDiscoHash = this.userDiscoInfo.hash;
         this.userDiscoInfo.node = `${NODE_NAME}#${this.userDiscoHash}`;
+    }
+
+    /** Push a Matrix room rename into the discovery cache (see existingAliases). */
+    public updateCachedRoomName(roomId: string, name?: string): void {
+        for (const entry of this.existingAliases.values()) {
+            if (entry.roomId === roomId) {
+                entry.name = name;
+                entry.fetchedAt = Date.now();
+            }
+        }
     }
 
     public parseAliasFromJID(to: JID): string|null {
@@ -283,11 +303,9 @@ export class ServiceHandler {
                 throw Error("Not a valid alias");
             }
             log.debug(`Running room discovery for ${toStr}`);
-            // The alias->roomId mapping is stable, but the name can change: re-query when we
-            // have no name cached so renames eventually propagate.
             let room = this.existingAliases.get(alias);
-            if (!room || !room.name) {
-                room = await this.queryRoom(alias);
+            if (!room || !room.name || Date.now() - room.fetchedAt > ROOM_NAME_CACHE_MS) {
+                room = { ...await this.queryRoom(alias), fetchedAt: Date.now() };
                 this.existingAliases.set(alias, room);
             }
             log.info(`Response for alias request ${toStr} (${alias}) -> ${room.roomId}`);

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -115,6 +115,10 @@ export class XmppJsGateway implements IGateway {
         return !!this.members.getXmppMemberByMatrixId(chatName, matrixId);
     }
 
+    public updateRoomName(roomId: string, name?: string) {
+        this.xmpp.serviceHandler.updateCachedRoomName(roomId, name);
+    }
+
     public isJIDInMuc(chatName: string, j: JID) {
         return !!this.members.getXmppMemberByDevice(chatName, j);
     }


### PR DESCRIPTION
Stacked on #378 (gh-stack style: based on `matthew/gateway-room-disco-names`; only the top commit is new).

Gateway disco name lookups were resolved once and cached forever. Push `m.room.name` state events into the cache (`IGateway.updateRoomName`) and add a 5-minute TTL for rooms nobody has joined yet, so renames show up in the XMPP room list without a bridge restart.

this PR was generated by Fable but reviewed by hand
