### PR TITLE
Don't content-dedupe inbound id-less presence stanzas

### DIFF
--- a/changelog.d/382.bugfix
+++ b/changelog.d/382.bugfix
@@ -1,0 +1,1 @@
+Fix a case where XMPP users may not be able to rejoin a Matrix room over the gateway.

--- a/src/xmppjs/XJSInstance.ts
+++ b/src/xmppjs/XJSInstance.ts
@@ -485,13 +485,34 @@ export class XmppJsInstance extends EventEmitter implements IBifrostInstance {
         return Buffer.from(stanza.toString()).toString("base64");
     }
 
-    private async onStanza(stanza: Element) {
-        const startedAt = Date.now();
+    /**
+     * Decide whether an inbound stanza is a duplicate that should be dropped, marking it
+     * as seen otherwise. Stanzas carrying an explicit id are deduplicated against ids we
+     * have seen or sent (self-echo suppression, see xmppAddSentMessage), and messages
+     * without an id get a content-derived one so that MUC fan-out copies (same from+body
+     * delivered once per bridged occupant) collapse to a single event. Presences without
+     * an id are never deduplicated: a MUC join -> part -> rejoin cycle legitimately
+     * repeats byte-identical presence stanzas, and content-dedup would silently eat the
+     * rejoin, permanently locking the user out of the room.
+     */
+    public isDuplicateStanza(stanza: Element): boolean {
+        const hasExplicitId = Boolean(stanza.attrs.id);
         const id = stanza.attrs.id = stanza.attrs.id || this.generateIdforMsg(stanza);
+        if (!hasExplicitId && !stanza.is("message")) {
+            return false;
+        }
         if (this.seenMessages.has(id)) {
-            return;
+            return true;
         }
         this.xmppAddSentMessage(id);
+        return false;
+    }
+
+    private async onStanza(stanza: Element) {
+        const startedAt = Date.now();
+        if (this.isDuplicateStanza(stanza)) {
+            return;
+        }
         log.debug("Stanza:", stanza.toJSON());
         const from = stanza.attrs.from ? jid(stanza.attrs.from) : null;
         const to = stanza.attrs.to ? jid(stanza.attrs.to) : null;
@@ -511,7 +532,7 @@ export class XmppJsInstance extends EventEmitter implements IBifrostInstance {
                         return;
                     }
                     else {
-                        log.debug(`Got a jingle request ${id}, but the bridge isn't configured to handle jingle`);
+                        log.debug(`Got a jingle request ${stanza.attrs.id}, but the bridge isn't configured to handle jingle`);
                     }
                 } else if (stanza.is("iq") && stanza.getChildByAttr('xmlns', 'http://jabber.org/protocol/ibb')) {
                     // This is an "open" reqyest
@@ -521,7 +542,7 @@ export class XmppJsInstance extends EventEmitter implements IBifrostInstance {
                         return;
                     }
                     else {
-                        log.debug(`Got a 'open' (IBB) request ${id}, but the bridge isn't configured to handle jingle`);
+                        log.debug(`Got a 'open' (IBB) request ${stanza.attrs.id}, but the bridge isn't configured to handle jingle`);
                     }
                 } else if (stanza.is("iq") && ["get", "set"].includes(stanza.getAttr("type"))) {
                     await this.serviceHandler.handleIq(stanza, this.bridge.getIntent());
@@ -542,7 +563,7 @@ export class XmppJsInstance extends EventEmitter implements IBifrostInstance {
             } else if (stanza.is("iq") &&
                 ["result", "error"].includes(stanza.getAttr("type")) &&
                 stanza.attrs.id) {
-                this.emit("iq." + id, stanza);
+                this.emit("iq." + stanza.attrs.id, stanza);
             } else if (stanza.is("iq") && stanza.getAttr("type") === "get" && isOurs) {
                 this.serviceHandler.handleIq(stanza, this.bridge.getIntent());
             }

--- a/test/xmppjs/test_XJSInstance.ts
+++ b/test/xmppjs/test_XJSInstance.ts
@@ -2,6 +2,7 @@
 import * as Chai from "chai";
 import { Config } from "../../src/Config";
 import { XmppJsInstance, XMPP_PROTOCOL } from "../../src/xmppjs/XJSInstance";
+import { x } from "@xmpp/xml";
 
 const expect = Chai.expect;
 
@@ -27,6 +28,62 @@ describe("XJSInstance", () => {
         const res = instance.getUsernameFromMxid("@_xmpp_frogdevice=2ffrogman=40frogplanet.com:example.com", "_xmpp_");
         expect(res.protocol).to.equal(XMPP_PROTOCOL);
         expect(res.username).to.equal("frogman@frogplanet.com/frogdevice");
+    });
+
+    describe("isDuplicateStanza", () => {
+        const mucJoin = () => x("presence", {
+            from: "user@example.com/res1",
+            to: "#room#server@gateway.example.com/nick",
+        }, x("x", {xmlns: "http://jabber.org/protocol/muc"}));
+
+        it("should dedupe stanzas with an explicit id", () => {
+            const instance = new XmppJsInstance(config, {} as any);
+            const stanza = () => x("message", {
+                from: "user@example.com/res1", to: "room@muc.example.com", id: "abc123",
+            }, x("body", {}, "hello"));
+            expect(instance.isDuplicateStanza(stanza())).to.equal(false);
+            expect(instance.isDuplicateStanza(stanza())).to.equal(true);
+        });
+
+        it("should dedupe id-less messages by content (MUC fan-out copies)", () => {
+            const instance = new XmppJsInstance(config, {} as any);
+            const stanza = () => x("message", {
+                from: "room@muc.example.com/nick", to: "ghost1@gateway.example.com", type: "groupchat",
+            }, x("body", {}, "fan-out"));
+            expect(instance.isDuplicateStanza(stanza())).to.equal(false);
+            expect(instance.isDuplicateStanza(stanza())).to.equal(true);
+        });
+
+        it("should drop stanzas whose id was registered as sent (self-echo)", () => {
+            const instance = new XmppJsInstance(config, {} as any);
+            instance.xmppAddSentMessage("sent-id-1");
+            const echo = x("message", {
+                from: "room@muc.example.com/mynick", to: "me@example.com", id: "sent-id-1",
+            }, x("body", {}, "my own message"));
+            expect(instance.isDuplicateStanza(echo)).to.equal(true);
+        });
+
+        it("should NOT dedupe an id-less MUC rejoin presence", () => {
+            // join -> part -> rejoin: the rejoin presence is byte-identical to the join.
+            // Content-dedup used to eat it, permanently locking the user out of the room.
+            const instance = new XmppJsInstance(config, {} as any);
+            expect(instance.isDuplicateStanza(mucJoin())).to.equal(false);
+            expect(instance.isDuplicateStanza(x("presence", {
+                from: "user@example.com/res1",
+                to: "#room#server@gateway.example.com/nick",
+                type: "unavailable",
+            }))).to.equal(false);
+            expect(instance.isDuplicateStanza(mucJoin())).to.equal(false);
+        });
+
+        it("should still dedupe presences that carry an explicit id", () => {
+            const instance = new XmppJsInstance(config, {} as any);
+            const stanza = () => x("presence", {
+                from: "user@example.com/res1", to: "other@example.com", id: "pres-1",
+            });
+            expect(instance.isDuplicateStanza(stanza())).to.equal(false);
+            expect(instance.isDuplicateStanza(stanza())).to.equal(true);
+        });
     });
 
     it("should be able to transform a xmpp username to a mxid and back", () => {


### PR DESCRIPTION
Inbound stanzas without an id are deduplicated by a content-derived id (base64 of the serialised stanza). A MUC join → part → rejoin cycle repeats a byte-identical join presence, so the rejoin was silently dropped and the user could never rejoin the room from the same session. Presences without an id are no longer content-deduped; messages (MUC fan-out collapse) and explicit-id stanzas (self-echo suppression) keep the existing behaviour.

this PR was generated by Fable but reviewed by hand
