### PR TITLE
Don't overwrite an existing room name when handling a chat topic

### DIFF
--- a/changelog.d/384.bugfix
+++ b/changelog.d/384.bugfix
@@ -1,0 +1,1 @@
+Fix the room name being reset to the room's address whenever a user joins.

--- a/spec/muc-portal.spec.ts
+++ b/spec/muc-portal.spec.ts
@@ -1,11 +1,16 @@
 import { describe, expect } from "vitest";
-import { xml } from "@xmpp/client";
+import { xml, client as xmppClient } from "@xmpp/client";
 import { test as baseTest } from "./util/fixtures";
 import { XMPP_MUC_DOMAIN } from "./util/containers/prosody";
 
 const MUC_ROOM_LOCALPART = "e2eroom";
 const MUC_ROOM_NAME = "E2E Test Room";
 const MUC_ROOM_JID = `${MUC_ROOM_LOCALPART}@${XMPP_MUC_DOMAIN}`;
+
+const TOPIC_MUC_ROOM_LOCALPART = "e2eroom-topic";
+const TOPIC_MUC_ROOM_NAME = "E2E Topic Test Room";
+const TOPIC_MUC_ROOM_JID = `${TOPIC_MUC_ROOM_LOCALPART}@${XMPP_MUC_DOMAIN}`;
+const MUC_SUBJECT = "Welcome to the test room";
 
 const test = baseTest.override("testEnvOpts", () => ({
     config: {
@@ -23,38 +28,44 @@ const test = baseTest.override("testEnvOpts", () => ({
     },
 }));
 
-describe("XMPP MUC portal rooms", () => {
-    test("names the Matrix portal room after the MUC's disco#info identity name", async ({ testEnv, alice }) => {
-        // Join the MUC as its first occupant (making us the owner), then set the room's
-        // human-readable name via the XEP-0045 configuration form. That name ends up in
-        // the MUC's disco#info identity, which the bridge reads to name the portal room.
-        await testEnv.xmpp.send(xml(
-            "presence",
-            { to: `${MUC_ROOM_JID}/owner` },
-            xml("x", { xmlns: "http://jabber.org/protocol/muc" }),
-        ));
-        await testEnv.xmpp.iqCaller.request(xml(
-            "iq",
-            { type: "set", to: MUC_ROOM_JID },
+/**
+ * Joins a MUC as its first occupant (making the client the owner) and sets the room's
+ * human-readable name via the XEP-0045 configuration form, so the bridge's disco#info-based
+ * portal naming has something to read.
+ */
+async function joinAsOwnerAndSetName(xmpp: ReturnType<typeof xmppClient>, mucJid: string, name: string) {
+    await xmpp.send(xml(
+        "presence",
+        { to: `${mucJid}/owner` },
+        xml("x", { xmlns: "http://jabber.org/protocol/muc" }),
+    ));
+    await xmpp.iqCaller.request(xml(
+        "iq",
+        { type: "set", to: mucJid },
+        xml(
+            "query",
+            { xmlns: "http://jabber.org/protocol/muc#owner" },
             xml(
-                "query",
-                { xmlns: "http://jabber.org/protocol/muc#owner" },
+                "x",
+                { xmlns: "jabber:x:data", type: "submit" },
                 xml(
-                    "x",
-                    { xmlns: "jabber:x:data", type: "submit" },
-                    xml(
-                        "field",
-                        { var: "FORM_TYPE", type: "hidden" },
-                        xml("value", {}, "http://jabber.org/protocol/muc#roomconfig"),
-                    ),
-                    xml(
-                        "field",
-                        { var: "muc#roomconfig_roomname" },
-                        xml("value", {}, MUC_ROOM_NAME),
-                    ),
+                    "field",
+                    { var: "FORM_TYPE", type: "hidden" },
+                    xml("value", {}, "http://jabber.org/protocol/muc#roomconfig"),
+                ),
+                xml(
+                    "field",
+                    { var: "muc#roomconfig_roomname" },
+                    xml("value", {}, name),
                 ),
             ),
-        ));
+        ),
+    ));
+}
+
+describe("XMPP MUC portal rooms", () => {
+    test("names the Matrix portal room after the MUC's disco#info identity name", async ({ testEnv, alice }) => {
+        await joinAsOwnerAndSetName(testEnv.xmpp, MUC_ROOM_JID, MUC_ROOM_NAME);
 
         const roomName = alice.waitForRoomEvent({
             eventType: "m.room.name", sender: testEnv.botMxid, stateKey: "",
@@ -64,5 +75,31 @@ describe("XMPP MUC portal rooms", () => {
 
         const { data } = await roomName;
         expect((data.content as { name: string }).name).toEqual(MUC_ROOM_NAME);
+    });
+
+    test("keeps a portal room's existing name when the MUC subject is delivered on join", async ({ testEnv, alice }) => {
+        // A MUC redelivers its current subject to every newly-joining occupant - including the
+        // bridge's own ghost, joining on Alice's behalf as she joins the portal. handleTopic used
+        // to treat that redelivery as a rename, resetting the room's name (set here from the MUC's
+        // disco#info identity, same as the previous test) back to the raw MUC JID every time.
+        await joinAsOwnerAndSetName(testEnv.xmpp, TOPIC_MUC_ROOM_JID, TOPIC_MUC_ROOM_NAME);
+        await testEnv.xmpp.send(xml(
+            "message",
+            { type: "groupchat", to: TOPIC_MUC_ROOM_JID },
+            xml("subject", {}, MUC_SUBJECT),
+        ));
+
+        // Registered before joining so we can't miss the topic event to a race.
+        const topicSet = alice.waitForRoomEvent({
+            eventType: "m.room.topic", sender: testEnv.botMxid, stateKey: "",
+        });
+
+        await alice.joinRoom(`#_bifrost_${TOPIC_MUC_ROOM_LOCALPART}:${testEnv.serverName}`);
+
+        const { roomId, data } = await topicSet;
+        expect((data.content as { topic: string }).topic).toEqual(MUC_SUBJECT);
+
+        const nameContent = await alice.getRoomStateEvent(roomId, "m.room.name", "") as { name: string };
+        expect(nameContent.name).toEqual(TOPIC_MUC_ROOM_NAME);
     });
 });

--- a/spec/muc-portal.spec.ts
+++ b/spec/muc-portal.spec.ts
@@ -89,7 +89,7 @@ describe("XMPP MUC portal rooms", () => {
             xml("subject", {}, MUC_SUBJECT),
         ));
 
-        // Registered before joining so we can't miss the topic event to a race.
+        // Registered before joining so we don't lose the topic event to a race.
         const topicSet = alice.waitForRoomEvent({
             eventType: "m.room.topic", sender: testEnv.botMxid, stateKey: "",
         });

--- a/spec/util/bifrost-env.ts
+++ b/spec/util/bifrost-env.ts
@@ -201,13 +201,19 @@ export class BifrostTestEnv {
 
     public async tearDown(): Promise<void> {
         await Promise.allSettled([
-            this.bridge?.killBridge(),
             this.xmppClient?.stop(),
             ...[...this.users.values()].map((u) => u.stop()),
         ]);
+        // Synapse pushes AS transactions to the bridge's HTTP listener asynchronously, so stop
+        // it before killing the bridge - otherwise a straggling push can land on a port that's
+        // already closed. Testcontainers relays that inbound connection back to the host via an
+        // SSH tunnel (see exposeHostPorts in containers/index.ts) whose relay socket has no
+        // error handler, so an ECONNREFUSED there crashes the whole test process instead of
+        // just failing a request.
+        await this.containers?.synapse.stop();
+        await this.bridge?.killBridge();
         await Promise.allSettled([
             this.dbName && this.containers ? dropDatabase(this.containers.postgres, this.dbName) : Promise.resolve(),
-            this.containers?.synapse.stop(),
             this.containers?.prosody.stop(),
             this.containers?.postgres.stop(),
         ]);

--- a/src/MatrixRoomHandler.ts
+++ b/src/MatrixRoomHandler.ts
@@ -653,13 +653,17 @@ export class MatrixRoomHandler {
         const topicEv = state.find((ev) => ev.type === "m.room.topic");
         const nameEv = state.find((ev) => ev.type === "m.room.name");
         const currentName = nameEv ? nameEv.content.name : "";
-        const currentTopic = topicEv ? topicEv.content.name : "";
-        if (currentTopic !== data.topic ? data.topic : "") {
-            intent.setRoomTopic(roomId, data.topic || "").catch((err) => {
+        const currentTopic = topicEv ? topicEv.content.topic : "";
+        if (data.topic && data.topic !== currentTopic) {
+            intent.setRoomTopic(roomId, data.topic).catch((err) => {
                 log.warn("Failed to set topic of", roomId, err);
             });
         }
-        if (currentName !== data.conv.name) {
+        // conv.name is not a human-readable name on all protocols — XMPP conversations are
+        // named by their raw MUC JID — and the topic is (re)delivered on every join, so
+        // overwriting here would keep resetting a room name the room's admins (or portal
+        // creation) chose back to the JID. Only fill the name in when the room has none.
+        if (!currentName) {
             intent.setRoomName(roomId, data.conv.name).catch((err) => {
                 log.warn("Failed to set name of", roomId, err);
             });

--- a/test/test_matrixroomhandler.ts
+++ b/test/test_matrixroomhandler.ts
@@ -1,0 +1,71 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as Chai from "chai";
+import { EventEmitter } from "events";
+import { MatrixRoomHandler } from "../src/MatrixRoomHandler";
+import { Config } from "../src/Config";
+const expect = Chai.expect;
+
+const ROOM_ID = "!room:localhost";
+const MUC_JID = "muc@conference.localhost";
+
+function createHandler(roomState: any[]) {
+    const purple: any = new EventEmitter();
+    purple.needsDedupe = () => false;
+    purple.needsAccountLock = () => false;
+    const calls: {setRoomName: any[]; setRoomTopic: any[]} = { setRoomName: [], setRoomTopic: [] };
+    const intent = {
+        roomState: async () => roomState,
+        setRoomName: async (roomId: string, name: string) => { calls.setRoomName.push([roomId, name]); },
+        setRoomTopic: async (roomId: string, topic: string) => { calls.setRoomTopic.push([roomId, topic]); },
+    };
+    const bridge: any = { getIntent: () => intent };
+    const handler = new MatrixRoomHandler(
+        purple, {} as any, {} as any, new Config(), {} as any, bridge,
+    ) as any;
+    handler.createOrGetGroupChatRoom = async () => ROOM_ID;
+    return { handler, calls };
+}
+
+function topicEvent(topic = "the topic") {
+    return {
+        eventName: "chat-topic",
+        conv: { name: MUC_JID },
+        account: { protocol_id: "prpl-dummy", username: "acct" },
+        sender: `${MUC_JID}/someone`,
+        topic,
+    };
+}
+
+describe("MatrixRoomHandler", () => {
+    describe("handleTopic", () => {
+        it("should not overwrite an existing room name with the conversation name", async () => {
+            // The topic is (re)delivered on every join, and conv.name is the raw MUC JID on
+            // XMPP — overwriting kept resetting a human-set room name back to the JID.
+            const { handler, calls } = createHandler([
+                { type: "m.room.name", content: { name: "A Human Name" } },
+            ]);
+            await handler.handleTopic(topicEvent());
+            expect(calls.setRoomName).to.be.empty;
+        });
+
+        it("should name a room that has no name yet", async () => {
+            const { handler, calls } = createHandler([]);
+            await handler.handleTopic(topicEvent());
+            expect(calls.setRoomName).to.deep.equal([[ROOM_ID, MUC_JID]]);
+        });
+
+        it("should set a changed topic and skip an unchanged one", async () => {
+            const { handler, calls } = createHandler([
+                { type: "m.room.name", content: { name: "A Human Name" } },
+                { type: "m.room.topic", content: { topic: "old topic" } },
+            ]);
+            await handler.handleTopic(topicEvent("new topic"));
+            expect(calls.setRoomTopic).to.deep.equal([[ROOM_ID, "new topic"]]);
+            calls.setRoomTopic.length = 0;
+            // unchanged topic: reads content.topic (was content.name, so every redelivery
+            // re-sent an identical m.room.topic state event)
+            await handler.handleTopic(topicEvent("old topic"));
+            expect(calls.setRoomTopic).to.be.empty;
+        });
+    });
+});


### PR DESCRIPTION
The MUC subject is redelivered to every joining occupant, and `handleTopic` set `m.room.name` to `conv.name` (the raw MUC JID on XMPP) whenever it differed — so every Matrix-side join renamed the room back to its JID, clobbering any human-set name. Only fill the name in when the room has none. Also fixes the topic comparison reading `content.name` off the `m.room.topic` event, which re-sent an identical topic state event on every join.

this PR was generated by Fable but reviewed by hand
