### PR TITLE
Advertise full JIDs in gateway occupant presence items

### DIFF
--- a/changelog.d/385.bugfix
+++ b/changelog.d/385.bugfix
@@ -1,0 +1,1 @@
+Advertise occupants' full JIDs in gateway room presence, fixing private-chat actions on bridged users in some XMPP clients.

--- a/spec/gateway-participation.spec.ts
+++ b/spec/gateway-participation.spec.ts
@@ -1,0 +1,241 @@
+import { describe, expect } from "vitest";
+import { xml, client as xmppClient } from "@xmpp/client";
+import { jid } from "@xmpp/jid";
+import type { Element } from "@xmpp/xml";
+import { test as baseTest } from "./util/fixtures";
+import { XMPP_COMPONENT_DOMAIN, XMPP_C2S_DOMAIN, XMPP_TEST_USER } from "./util/containers/prosody";
+import { ghostMxidForXmppUser } from "./util/bifrost-env";
+import type { BifrostTestEnv, BifrostTestEnvOpts } from "./util/bifrost-env";
+import type { E2ETestMatrixClient } from "./util/e2e-test";
+
+const STANZA_WAIT_TIMEOUT = parseInt(process.env.BIFROST_TEST_WAIT_TIMEOUT ?? "20000", 10);
+
+// Gateway room support only runs when portals.enableGateway is set - see XJSInstance#preStart.
+// Carol is a second Matrix user who joins a room and never leaves, purely so the membership
+// test below has a stable observer for both Alice's and Bob's departures - whichever of the
+// two of them leaves last has nobody left in the room to confirm their own leave from the
+// Matrix side. The environment (and so its user list) is booted once per file, shared by both
+// tests below, so she's declared here even though the messaging test doesn't use her.
+const test = baseTest.override("testEnvOpts", {
+    matrixLocalparts: ["alice", "carol"],
+    config: {
+        portals: { enableGateway: true },
+    },
+} as BifrostTestEnvOpts);
+
+async function createPublicRoom(
+    testEnv: BifrostTestEnv, alice: E2ETestMatrixClient, aliasLocalpart: string, name: string,
+): Promise<string> {
+    const roomId = await alice.createRoom({
+        visibility: "public",
+        preset: "public_chat",
+        name,
+        room_alias_name: aliasLocalpart,
+    });
+    const alias = `#${aliasLocalpart}:${testEnv.serverName}`;
+    // createRoom's room_alias_name maps the alias but does not set canonical_alias itself.
+    await alice.sendStateEvent(roomId, "m.room.canonical_alias", "", { alias });
+    return alias;
+}
+
+// Mirrors ServiceHandler#createJIDFromAlias, so tests can address a gateway room's JID directly.
+function roomJid(alias: string): string {
+    const [local, server] = alias.replace(/^#/, "").split(":");
+    return `#${local}#${server}@${XMPP_COMPONENT_DOMAIN}`;
+}
+
+function waitForStanza(
+    xmpp: ReturnType<typeof xmppClient>, description: string, predicate: (stanza: Element) => boolean,
+    timeoutMs = STANZA_WAIT_TIMEOUT,
+): Promise<Element> {
+    return new Promise((resolve, reject) => {
+        const onStanza = (stanza: Element) => {
+            if (predicate(stanza)) {
+                clearTimeout(timer);
+                xmpp.removeListener("stanza", onStanza);
+                resolve(stanza);
+            }
+        };
+        const timer = setTimeout(() => {
+            xmpp.removeListener("stanza", onStanza);
+            reject(new Error(`Timed out waiting for stanza: ${description}`));
+        }, timeoutMs);
+        xmpp.on("stanza", onStanza);
+    });
+}
+
+function isPresenceFrom(stanza: Element, from: string): boolean {
+    return stanza.is("presence") && stanza.attrs.from === from;
+}
+
+function hasMucStatusCode(stanza: Element, code: string): boolean {
+    return !!stanza.getChild("x", "http://jabber.org/protocol/muc#user")
+        ?.getChildren("status")
+        .some((s) => s.attrs.code === code);
+}
+
+/**
+ * Tracks the occupants of a gateway room from incoming presence broadcasts, the way a real
+ * XMPP client builds its member list - there's no disco#items support for the occupants of a
+ * specific gateway room (only for listing rooms themselves), see ServiceHandler#handleIq.
+ */
+class OccupantTracker {
+    private readonly nicks = new Set<string>();
+    private readonly handler = (stanza: Element) => {
+        if (!stanza.is("presence") || !stanza.attrs.from) {
+            return;
+        }
+        const from = jid(stanza.attrs.from);
+        if (!from.resource || `${from.local}@${from.domain}` !== this.chatJid) {
+            return;
+        }
+        if (stanza.attrs.type === "unavailable") {
+            this.nicks.delete(from.resource);
+        } else {
+            this.nicks.add(from.resource);
+        }
+    };
+
+    constructor(private xmpp: ReturnType<typeof xmppClient>, private chatJid: string) {
+        xmpp.on("stanza", this.handler);
+    }
+
+    public get occupantNicks(): string[] {
+        return [...this.nicks].sort();
+    }
+
+    public stop(): void {
+        this.xmpp.removeListener("stanza", this.handler);
+    }
+}
+
+/** Sends the MUC join presence used to enter a gateway room, and waits for the self-presence ack. */
+async function joinGateway(testEnv: BifrostTestEnv, joinTo: string): Promise<void> {
+    const selfPresence = waitForStanza(
+        testEnv.xmpp, "self-presence confirming gateway join",
+        (s) => isPresenceFrom(s, joinTo) && hasMucStatusCode(s, "110"),
+    );
+    await testEnv.xmpp.send(xml(
+        "presence", { to: joinTo },
+        xml("x", { xmlns: "http://jabber.org/protocol/muc" }),
+    ));
+    await selfPresence;
+}
+
+describe("XMPP gateway participation", () => {
+    test("bridges bidirectional messages between a Matrix user and an XMPP user", async ({ testEnv, alice }) => {
+        const bobNick = "bob";
+        const bobBareJid = `${XMPP_TEST_USER}@${XMPP_C2S_DOMAIN}`;
+        const bobGhostMxid = ghostMxidForXmppUser(testEnv.serverName, bobBareJid);
+
+        // Gives Alice's occupant nick in the gateway room a stable value (otherwise it falls
+        // back to her raw mxid - see GatewayStateResolve#resolveMatrixStateToXMPP).
+        await alice.setDisplayName("Alice");
+        const alias = await createPublicRoom(testEnv, alice, "gateway-messaging-room", "Gateway Messaging Room");
+        const roomId = await alice.resolveRoom(alias);
+        const chatJid = roomJid(alias);
+        const joinTo = `${chatJid}/${bobNick}`;
+
+        await joinGateway(testEnv, joinTo);
+
+        const matrixMsgToXmpp = waitForStanza(
+            testEnv.xmpp, "groupchat message relayed from Matrix",
+            (s) => s.is("message") && s.attrs.type === "groupchat" && s.getChildText("body") === "hello from matrix",
+        );
+        await alice.sendMessage(roomId, { msgtype: "m.text", body: "hello from matrix" });
+        const matrixMsgStanza = await matrixMsgToXmpp;
+        // The sender's occupant JID is anonymised to <room>/<nick> - Alice's ghost isn't exposed.
+        expect(matrixMsgStanza.attrs.from).toEqual(`${chatJid}/Alice`);
+
+        const xmppMsgToMatrix = alice.waitForRoomEvent({
+            eventType: "m.room.message", sender: bobGhostMxid, roomId,
+        });
+        await testEnv.xmpp.send(xml(
+            "message",
+            { type: "groupchat", to: chatJid, from: testEnv.xmpp.jid?.toString() },
+            xml("body", {}, "hello from xmpp"),
+        ));
+        const { data: xmppMsgData } = await xmppMsgToMatrix;
+        expect((xmppMsgData.content as { body: string }).body).toEqual("hello from xmpp");
+    });
+
+    test(
+        "keeps the memberlist correct on both sides as a Matrix user and an XMPP user join and leave",
+        { timeout: 60000 },
+        async ({ testEnv, alice }) => {
+            // Carol never leaves - she's here purely so the Matrix-side memberlist can still be
+            // checked after whichever of Alice/Bob leaves last (at that point there's nobody
+            // else left in the room to confirm it from the Matrix side).
+            const carol = testEnv.getUser("carol");
+            const bobNick = "bob";
+            const bobBareJid = `${XMPP_TEST_USER}@${XMPP_C2S_DOMAIN}`;
+            const bobGhostMxid = ghostMxidForXmppUser(testEnv.serverName, bobBareJid);
+            const aliceMxid = `@alice:${testEnv.serverName}`;
+            const carolMxid = `@carol:${testEnv.serverName}`;
+
+            await alice.setDisplayName("Alice");
+            const alias = await createPublicRoom(testEnv, alice, "gateway-membership-room", "Gateway Membership Room");
+            const roomId = await carol.joinRoom(alias);
+            const chatJid = roomJid(alias);
+            const joinTo = `${chatJid}/${bobNick}`;
+
+            expect((await carol.getJoinedRoomMembers(roomId)).sort()).toEqual([aliceMxid, carolMxid].sort());
+
+            const tracker = new OccupantTracker(testEnv.xmpp, chatJid);
+
+            // --- Bob (XMPP) joins ---
+            const bobGhostJoined = carol.waitForRoomEvent({
+                eventType: "m.room.member", sender: bobGhostMxid, stateKey: bobGhostMxid, roomId,
+            });
+            await joinGateway(testEnv, joinTo);
+            const { data: joinData } = await bobGhostJoined;
+            expect((joinData.content as { membership: string }).membership).toEqual("join");
+
+            expect((await carol.getJoinedRoomMembers(roomId)).sort()).toEqual(
+                [aliceMxid, carolMxid, bobGhostMxid].sort(),
+            );
+            expect(tracker.occupantNicks).toEqual(expect.arrayContaining(["Alice", bobNick]));
+
+            // --- Alice (Matrix) leaves - Bob is still in the room to observe the XMPP side, and
+            // Carol observes the Matrix side ---
+            const aliceLeftMatrix = carol.waitForRoomEvent({
+                eventType: "m.room.member", sender: aliceMxid, stateKey: aliceMxid, roomId,
+            });
+            const aliceLeftXmpp = waitForStanza(
+                testEnv.xmpp, "presence unavailable for Alice leaving",
+                (s) => isPresenceFrom(s, `${chatJid}/Alice`) && s.attrs.type === "unavailable",
+            );
+            await alice.leaveRoom(roomId);
+            const { data: aliceLeaveData } = await aliceLeftMatrix;
+            await aliceLeftXmpp;
+            expect((aliceLeaveData.content as { membership: string }).membership).toEqual("leave");
+            expect((await carol.getJoinedRoomMembers(roomId)).sort()).toEqual([carolMxid, bobGhostMxid].sort());
+            expect(tracker.occupantNicks).not.toContain("Alice");
+
+            // --- Bob (XMPP) leaves - Carol observes the Matrix side, Bob observes his own
+            // self-presence confirming the leave ---
+            const bobGhostLeft = carol.waitForRoomEvent({
+                eventType: "m.room.member", sender: bobGhostMxid, stateKey: bobGhostMxid, roomId,
+            });
+            const bobSelfLeavePresence = waitForStanza(
+                testEnv.xmpp, "self-presence confirming gateway leave",
+                (s) => isPresenceFrom(s, joinTo) && s.attrs.type === "unavailable" && hasMucStatusCode(s, "110"),
+            );
+            await testEnv.xmpp.send(xml("presence", { type: "unavailable", to: joinTo }));
+            await bobSelfLeavePresence;
+            const { data: bobLeaveData } = await bobGhostLeft;
+            expect((bobLeaveData.content as { membership: string }).membership).toEqual("leave");
+            expect(await carol.getJoinedRoomMembers(roomId)).toEqual([carolMxid]);
+
+            const messageAfterLeave = waitForStanza(
+                testEnv.xmpp, "message delivered to Bob after he left (should not happen)",
+                (s) => s.is("message") && s.getChildText("body") === "should not reach a departed member",
+                3000,
+            );
+            await carol.sendMessage(roomId, { msgtype: "m.text", body: "should not reach a departed member" });
+            await expect(messageAfterLeave).rejects.toThrow();
+
+            tracker.stop();
+        },
+    );
+});

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -11,7 +11,7 @@ export async function initiateStore(config: IConfigDatastore, bridge: Bridge): P
     if (config.engine === "nedb") {
         return new NeDBStore(bridge);
     } else if (config.engine === "postgres") {
-        const pg = new PgDataStore(config);
+        const pg = new PgDataStore(config, bridge);
         await pg.ensureSchema();
         return pg;
     }

--- a/src/store/postgres/PgDatastore.ts
+++ b/src/store/postgres/PgDatastore.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { Pool } from "pg";
-import { MatrixRoom, RemoteRoom, MatrixUser, Logger, RoomBridgeStoreEntry } from "matrix-appservice-bridge";
+import { MatrixRoom, RemoteRoom, MatrixUser, Logger, RoomBridgeStoreEntry, Bridge, AppServiceBot } from "matrix-appservice-bridge";
 import { IRemoteGroupData, MROOM_TYPES, RoomTypeToRemoteRoomData,
     IRemoteImData, IRemoteUserAdminData, MROOM_TYPE_IM, MROOM_TYPE_GROUP, MROOM_TYPE_UADMIN } from "../Types";
 import { BifrostProtocol } from "../../bifrost/Protocol";
@@ -147,8 +147,10 @@ export class PgDataStore implements IStore {
     }
     private pgPool: Pool;
     private hasEnded: boolean = false;
+    private asBot: AppServiceBot;
 
-    constructor(config: IConfigDatastore) {
+    constructor(config: IConfigDatastore, bridge: Bridge) {
+        this.asBot = bridge.getBot();
         const opts = config.opts || {
             min: 1,
             max: 4,
@@ -217,7 +219,7 @@ export class PgDataStore implements IStore {
             Util.createRemoteId(protocol.id, sender),
             sender,
             protocol.id,
-            row.is_ghost,
+            this.asBot.isRemoteUser(row.user_id),
             row.displayname,
             row.extra_data,
         );

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -593,8 +593,8 @@ export class XmppJsGateway implements IGateway {
             stanza.attrs.from,
         );
         leaveStza.presenceType = "unavailable";
-        this.xmpp.xmppWriteToStream(leaveStza);
-        this.upsertXMPPUser(stanza.attrs.from, user.matrixId);
+        this.xmpp.xmppSend(leaveStza);
+        this.upsertXMPPUser(jid(stanza.attrs.from), user.matrixId);
         // If this is the last device for that member, reflect
         // that change to everyone.
         if (lastDevice) {

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -358,13 +358,20 @@ export class XmppJsGateway implements IGateway {
                 continue;
             }
             allMembershipPromises.push((async () => {
+                // XEP-0045 §7.2.3: in a non-anonymous room the <item jid=…> is the occupant's
+                // FULL JID. Emitting a bare JID here breaks clients that (reasonably) parse it
+                // as one — e.g. Smack's EntityFullJid — killing "open private chat" style
+                // actions on the occupant. XMPP members: use one of their device sessions;
+                // Matrix members: qualify the bridge ghost JID with the bridge resource
+                // (routing back to us is domain-based, so the resource is inert).
                 let realJid;
-                if ((member as IGatewayMemberXmpp).realJid) {
-                    realJid = (member as IGatewayMemberXmpp).realJid.toString();
+                const xmppMember = member as IGatewayMemberXmpp;
+                if (xmppMember.realJid) {
+                    realJid = [...xmppMember.devices][0] ?? xmppMember.realJid.toString();
                 } else {
                     realJid = this.registration.generateParametersFor(
                         XMPP_PROTOCOL.id, (member as IGatewayMemberMatrix).matrixId,
-                    ).username;
+                    ).username + "/" + this.xmpp.defaultResource;
                 }
                 return this.xmpp.xmppSend(
                     new StzaPresenceItem(

--- a/src/xmppjs/XJSInstance.ts
+++ b/src/xmppjs/XJSInstance.ts
@@ -340,7 +340,9 @@ export class XmppJsInstance extends EventEmitter implements IBifrostInstance {
         }
         if (aJid.domain === this.myAddress.domain) {
             log.debug(aJid.local, [...this.accounts.keys()]);
-            return this.accounts.get(aJid.toString());
+            // Accounts are keyed by bare JID; the request may address a full JID (e.g. a
+            // vCard fetch against the full JID we advertise in MUC occupant items).
+            return this.accounts.get(`${aJid.local}@${aJid.domain}`);
         }
         return;
     }

--- a/test/mocks/XJSInstance.ts
+++ b/test/mocks/XJSInstance.ts
@@ -11,6 +11,7 @@ export class MockXJSInstance extends EventEmitter {
     public sentPackets: Element[] = [];
     public selfPingResponse: "respond-ok"|"respond-error"|"no-response" = "respond-error";
     public accountUsername!: string;
+    public readonly defaultResource = "matrix-bridge";
 
     public xmppAddSentMessage(id: string) {
         this.sentMessageIDs.push(id);

--- a/test/xmppjs/test_XJSGateway.ts
+++ b/test/xmppjs/test_XJSGateway.ts
@@ -18,7 +18,9 @@ function createGateway(config?: IConfigBridge) {
     }
     return {gw: new XmppJsGateway(mockXmpp as any, {
         generateParametersFor(protocol: string, mxId: string) {
-            return mxId.replace(/@/, "").replace(/:/g, "_") + "@bar";
+            // Matches AutoRegistration.generateParametersFor, which returns the parameter
+            // map for the protocol's registration step ({username} for XMPP).
+            return { username: mxId.replace(/@/, "").replace(/:/g, "_") + "@bar" };
         },
     } as any, config), mockXmpp};
 }
@@ -113,6 +115,9 @@ describe("XJSGateway", () => {
                 hTo: "frogman@froguniverse/frogdevice",
                 affiliation: "member",
                 role: "participant",
+                // XEP-0045 §7.2.3: the real JID advertised for an occupant must be a FULL
+                // JID — Smack-based clients cast it to EntityFullJid.
+                jid: "foo1_bar@bar/matrix-bridge",
             });
 
             expect(messages[1]).to.include({
@@ -120,6 +125,7 @@ describe("XJSGateway", () => {
                 hTo: "frogman@froguniverse/frogdevice",
                 affiliation: "member",
                 role: "participant",
+                jid: "foo2_bar@bar/matrix-bridge",
             });
 
             expect(messages[2]).to.include({


### PR DESCRIPTION
XEP-0045 §7.2.3 has non-anonymous rooms advertise the occupant's **full** JID in the `muc#user` `<item jid=…>`, but the gateway's occupant roster sent bare JIDs — the bridge ghost JID for Matrix members, the device-stripped JID for XMPP members. Clients that parse the advertised real JID as a full JID (e.g. Smack's `EntityFullJid`, backing right-click actions like opening a private chat with an occupant) throw a `ClassCastException` on the bare form.

Matrix members now get the ghost JID qualified with the bridge's default resource (routing back to the component is domain-based, so the resource is inert — DMs to the full JID deliver as before), and XMPP members get one of their real device sessions. Also fixes the vCard handler's account lookup, which used the request's to-address verbatim against a bare-JID-keyed map, so vCard fetches addressed to the full JID 404'd.

this PR was generated by Fable but reviewed by hand