### PR TITLE
Backfill history in gateway mode

### DIFF
--- a/changelog.d/227.feature
+++ b/changelog.d/227.feature
@@ -1,0 +1,1 @@
+Send room history to XMPP clients when they join.

--- a/changelog.d/389.feature
+++ b/changelog.d/389.feature
@@ -1,0 +1,1 @@
+History will now be sent to XMPP users on joining a gateway room, when requested.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -94,6 +94,10 @@ purple:
 portals:
   # Enable gateway support for protocols that support them, e.g. xmpp.js
   enableGateway: false
+  # Maximum number of messages to retain per gateway room for history backfill
+  # on join. Kept small and in-memory by design - this is a courtesy backfill,
+  # not a durable log. Defaults to 50 if not set.
+  # gatewayHistoryLimit: 50
   # List of regexes to match a alias that can be turned into a bridge.
   aliases:
     # This matches #_bifrost_ followed by anything

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -63,6 +63,8 @@ properties:
         properties:
             enableGateway:
                 type: boolean
+            gatewayHistoryLimit:
+                type: integer
             aliases:
                 type: object
                 propertyNames:

--- a/spec/gateway-history.spec.ts
+++ b/spec/gateway-history.spec.ts
@@ -1,13 +1,13 @@
 import { describe, expect } from "vitest";
-import { xml, client as xmppClient } from "@xmpp/client";
-import type { Element } from "@xmpp/xml";
+import { xml } from "@xmpp/client";
 import { test as baseTest } from "./util/fixtures";
-import { XMPP_COMPONENT_DOMAIN, XMPP_C2S_DOMAIN, XMPP_TEST_USER } from "./util/containers/prosody";
+import { XMPP_C2S_DOMAIN, XMPP_TEST_USER } from "./util/containers/prosody";
 import { ghostMxidForXmppUser } from "./util/bifrost-env";
-import type { BifrostTestEnv, BifrostTestEnvOpts } from "./util/bifrost-env";
-import type { E2ETestMatrixClient } from "./util/e2e-test";
-
-const STANZA_WAIT_TIMEOUT = parseInt(process.env.BIFROST_TEST_WAIT_TIMEOUT ?? "20000", 10);
+import type { BifrostTestEnvOpts } from "./util/bifrost-env";
+import {
+    createPublicRoom, roomJid, waitForStanza, collectStanzas, isDelayedGroupchatMessage,
+    joinGateway, leaveGateway,
+} from "./util/gateway";
 
 // Gateway room support only runs when portals.enableGateway is set - see XJSInstance#preStart.
 const test = baseTest.override("testEnvOpts", {
@@ -15,111 +15,6 @@ const test = baseTest.override("testEnvOpts", {
         portals: { enableGateway: true },
     },
 } as BifrostTestEnvOpts);
-
-async function createPublicRoom(
-    testEnv: BifrostTestEnv, alice: E2ETestMatrixClient, aliasLocalpart: string, name: string,
-): Promise<string> {
-    const roomId = await alice.createRoom({
-        visibility: "public",
-        preset: "public_chat",
-        name,
-        room_alias_name: aliasLocalpart,
-    });
-    const alias = `#${aliasLocalpart}:${testEnv.serverName}`;
-    // createRoom's room_alias_name maps the alias but does not set canonical_alias itself.
-    await alice.sendStateEvent(roomId, "m.room.canonical_alias", "", { alias });
-    return alias;
-}
-
-// Mirrors ServiceHandler#createJIDFromAlias, so tests can address a gateway room's JID directly.
-function roomJid(alias: string): string {
-    const [local, server] = alias.replace(/^#/, "").split(":");
-    return `#${local}#${server}@${XMPP_COMPONENT_DOMAIN}`;
-}
-
-function waitForStanza(
-    xmpp: ReturnType<typeof xmppClient>, description: string, predicate: (stanza: Element) => boolean,
-    timeoutMs = STANZA_WAIT_TIMEOUT,
-): Promise<Element> {
-    return new Promise((resolve, reject) => {
-        const onStanza = (stanza: Element) => {
-            if (predicate(stanza)) {
-                clearTimeout(timer);
-                xmpp.removeListener("stanza", onStanza);
-                resolve(stanza);
-            }
-        };
-        const timer = setTimeout(() => {
-            xmpp.removeListener("stanza", onStanza);
-            reject(new Error(`Timed out waiting for stanza: ${description}`));
-        }, timeoutMs);
-        xmpp.on("stanza", onStanza);
-    });
-}
-
-/** Collects `count` matching stanzas, in arrival order. Rejects if that many don't show up in time. */
-function collectStanzas(
-    xmpp: ReturnType<typeof xmppClient>, description: string, predicate: (stanza: Element) => boolean,
-    count: number, timeoutMs = STANZA_WAIT_TIMEOUT,
-): Promise<Element[]> {
-    return new Promise((resolve, reject) => {
-        const collected: Element[] = [];
-        const onStanza = (stanza: Element) => {
-            if (!predicate(stanza)) {
-                return;
-            }
-            collected.push(stanza);
-            if (collected.length >= count) {
-                clearTimeout(timer);
-                xmpp.removeListener("stanza", onStanza);
-                resolve(collected);
-            }
-        };
-        const timer = setTimeout(() => {
-            xmpp.removeListener("stanza", onStanza);
-            reject(new Error(`Timed out waiting for ${count} stanzas (got ${collected.length}): ${description}`));
-        }, timeoutMs);
-        xmpp.on("stanza", onStanza);
-    });
-}
-
-function isPresenceFrom(stanza: Element, from: string): boolean {
-    return stanza.is("presence") && stanza.attrs.from === from;
-}
-
-function hasMucStatusCode(stanza: Element, code: string): boolean {
-    return !!stanza.getChild("x", "http://jabber.org/protocol/muc#user")
-        ?.getChildren("status")
-        .some((s) => s.attrs.code === code);
-}
-
-function isDelayedGroupchatMessage(stanza: Element): boolean {
-    return stanza.is("message") && stanza.attrs.type === "groupchat"
-        && !!stanza.getChild("delay", "urn:xmpp:delay");
-}
-
-/** Sends the MUC join presence used to enter a gateway room, and waits for the self-presence ack. */
-async function joinGateway(testEnv: BifrostTestEnv, joinTo: string): Promise<void> {
-    const selfPresence = waitForStanza(
-        testEnv.xmpp, "self-presence confirming gateway join",
-        (s) => isPresenceFrom(s, joinTo) && hasMucStatusCode(s, "110"),
-    );
-    await testEnv.xmpp.send(xml(
-        "presence", { to: joinTo },
-        xml("x", { xmlns: "http://jabber.org/protocol/muc" }),
-    ));
-    await selfPresence;
-}
-
-/** Sends the MUC unavailable presence used to leave a gateway room, and waits for the self-presence ack. */
-async function leaveGateway(testEnv: BifrostTestEnv, joinTo: string): Promise<void> {
-    const selfPresence = waitForStanza(
-        testEnv.xmpp, "self-presence confirming gateway leave",
-        (s) => isPresenceFrom(s, joinTo) && s.attrs.type === "unavailable" && hasMucStatusCode(s, "110"),
-    );
-    await testEnv.xmpp.send(xml("presence", { type: "unavailable", to: joinTo }));
-    await selfPresence;
-}
 
 describe("XMPP gateway history backfill", () => {
     test("replays cached messages, in order, to an XMPP user rejoining a history-visible room", async ({ testEnv, alice }) => {

--- a/spec/gateway-history.spec.ts
+++ b/spec/gateway-history.spec.ts
@@ -1,0 +1,214 @@
+import { describe, expect } from "vitest";
+import { xml, client as xmppClient } from "@xmpp/client";
+import type { Element } from "@xmpp/xml";
+import { test as baseTest } from "./util/fixtures";
+import { XMPP_COMPONENT_DOMAIN, XMPP_C2S_DOMAIN, XMPP_TEST_USER } from "./util/containers/prosody";
+import { ghostMxidForXmppUser } from "./util/bifrost-env";
+import type { BifrostTestEnv, BifrostTestEnvOpts } from "./util/bifrost-env";
+import type { E2ETestMatrixClient } from "./util/e2e-test";
+
+const STANZA_WAIT_TIMEOUT = parseInt(process.env.BIFROST_TEST_WAIT_TIMEOUT ?? "20000", 10);
+
+// Gateway room support only runs when portals.enableGateway is set - see XJSInstance#preStart.
+const test = baseTest.override("testEnvOpts", {
+    config: {
+        portals: { enableGateway: true },
+    },
+} as BifrostTestEnvOpts);
+
+async function createPublicRoom(
+    testEnv: BifrostTestEnv, alice: E2ETestMatrixClient, aliasLocalpart: string, name: string,
+): Promise<string> {
+    const roomId = await alice.createRoom({
+        visibility: "public",
+        preset: "public_chat",
+        name,
+        room_alias_name: aliasLocalpart,
+    });
+    const alias = `#${aliasLocalpart}:${testEnv.serverName}`;
+    // createRoom's room_alias_name maps the alias but does not set canonical_alias itself.
+    await alice.sendStateEvent(roomId, "m.room.canonical_alias", "", { alias });
+    return alias;
+}
+
+// Mirrors ServiceHandler#createJIDFromAlias, so tests can address a gateway room's JID directly.
+function roomJid(alias: string): string {
+    const [local, server] = alias.replace(/^#/, "").split(":");
+    return `#${local}#${server}@${XMPP_COMPONENT_DOMAIN}`;
+}
+
+function waitForStanza(
+    xmpp: ReturnType<typeof xmppClient>, description: string, predicate: (stanza: Element) => boolean,
+    timeoutMs = STANZA_WAIT_TIMEOUT,
+): Promise<Element> {
+    return new Promise((resolve, reject) => {
+        const onStanza = (stanza: Element) => {
+            if (predicate(stanza)) {
+                clearTimeout(timer);
+                xmpp.removeListener("stanza", onStanza);
+                resolve(stanza);
+            }
+        };
+        const timer = setTimeout(() => {
+            xmpp.removeListener("stanza", onStanza);
+            reject(new Error(`Timed out waiting for stanza: ${description}`));
+        }, timeoutMs);
+        xmpp.on("stanza", onStanza);
+    });
+}
+
+/** Collects `count` matching stanzas, in arrival order. Rejects if that many don't show up in time. */
+function collectStanzas(
+    xmpp: ReturnType<typeof xmppClient>, description: string, predicate: (stanza: Element) => boolean,
+    count: number, timeoutMs = STANZA_WAIT_TIMEOUT,
+): Promise<Element[]> {
+    return new Promise((resolve, reject) => {
+        const collected: Element[] = [];
+        const onStanza = (stanza: Element) => {
+            if (!predicate(stanza)) {
+                return;
+            }
+            collected.push(stanza);
+            if (collected.length >= count) {
+                clearTimeout(timer);
+                xmpp.removeListener("stanza", onStanza);
+                resolve(collected);
+            }
+        };
+        const timer = setTimeout(() => {
+            xmpp.removeListener("stanza", onStanza);
+            reject(new Error(`Timed out waiting for ${count} stanzas (got ${collected.length}): ${description}`));
+        }, timeoutMs);
+        xmpp.on("stanza", onStanza);
+    });
+}
+
+function isPresenceFrom(stanza: Element, from: string): boolean {
+    return stanza.is("presence") && stanza.attrs.from === from;
+}
+
+function hasMucStatusCode(stanza: Element, code: string): boolean {
+    return !!stanza.getChild("x", "http://jabber.org/protocol/muc#user")
+        ?.getChildren("status")
+        .some((s) => s.attrs.code === code);
+}
+
+function isDelayedGroupchatMessage(stanza: Element): boolean {
+    return stanza.is("message") && stanza.attrs.type === "groupchat"
+        && !!stanza.getChild("delay", "urn:xmpp:delay");
+}
+
+/** Sends the MUC join presence used to enter a gateway room, and waits for the self-presence ack. */
+async function joinGateway(testEnv: BifrostTestEnv, joinTo: string): Promise<void> {
+    const selfPresence = waitForStanza(
+        testEnv.xmpp, "self-presence confirming gateway join",
+        (s) => isPresenceFrom(s, joinTo) && hasMucStatusCode(s, "110"),
+    );
+    await testEnv.xmpp.send(xml(
+        "presence", { to: joinTo },
+        xml("x", { xmlns: "http://jabber.org/protocol/muc" }),
+    ));
+    await selfPresence;
+}
+
+/** Sends the MUC unavailable presence used to leave a gateway room, and waits for the self-presence ack. */
+async function leaveGateway(testEnv: BifrostTestEnv, joinTo: string): Promise<void> {
+    const selfPresence = waitForStanza(
+        testEnv.xmpp, "self-presence confirming gateway leave",
+        (s) => isPresenceFrom(s, joinTo) && s.attrs.type === "unavailable" && hasMucStatusCode(s, "110"),
+    );
+    await testEnv.xmpp.send(xml("presence", { type: "unavailable", to: joinTo }));
+    await selfPresence;
+}
+
+describe("XMPP gateway history backfill", () => {
+    test("replays cached messages, in order, to an XMPP user rejoining a history-visible room", async ({ testEnv, alice }) => {
+        const bobNick = "bob";
+        const bobBareJid = `${XMPP_TEST_USER}@${XMPP_C2S_DOMAIN}`;
+        const bobGhostMxid = ghostMxidForXmppUser(testEnv.serverName, bobBareJid);
+
+        // Gives Alice's occupant nick in the gateway room a stable value (otherwise it falls
+        // back to her raw mxid - see GatewayStateResolve#resolveMatrixStateToXMPP).
+        await alice.setDisplayName("Alice");
+        // public_chat defaults history_visibility to "shared", which is what makes the gateway
+        // consider this room's history safe to replay to XMPP joiners - see
+        // GatewayHandler#getVirtualRoom's allowHistory computation.
+        const alias = await createPublicRoom(testEnv, alice, "gateway-history-room", "Gateway History Room");
+        const roomId = await alice.resolveRoom(alias);
+        const chatJid = roomJid(alias);
+        const joinTo = `${chatJid}/${bobNick}`;
+
+        await joinGateway(testEnv, joinTo);
+
+        // Three messages, alternating sender, land while Bob is present - each is cached as it
+        // is relayed (XJSGateway#sendMatrixMessage / #reflectXMPPMessage).
+        const firstToXmpp = waitForStanza(
+            testEnv.xmpp, "first live message", (s) => s.is("message") && s.getChildText("body") === "first message",
+        );
+        await alice.sendMessage(roomId, { msgtype: "m.text", body: "first message" });
+        await firstToXmpp;
+
+        const secondToMatrix = alice.waitForRoomEvent({ eventType: "m.room.message", sender: bobGhostMxid, roomId });
+        await testEnv.xmpp.send(xml(
+            "message", { type: "groupchat", to: chatJid, from: testEnv.xmpp.jid?.toString() },
+            xml("body", {}, "second message"),
+        ));
+        await secondToMatrix;
+
+        const thirdToXmpp = waitForStanza(
+            testEnv.xmpp, "third live message", (s) => s.is("message") && s.getChildText("body") === "third message",
+        );
+        await alice.sendMessage(roomId, { msgtype: "m.text", body: "third message" });
+        await thirdToXmpp;
+
+        // Bob leaves and rejoins - a fresh join, so any backfill he receives must come from the
+        // history cache rather than just being live traffic he was already subscribed to.
+        await leaveGateway(testEnv, joinTo);
+
+        const history = collectStanzas(
+            testEnv.xmpp, "replayed history on rejoin", isDelayedGroupchatMessage, 3,
+        );
+        await joinGateway(testEnv, joinTo);
+        const [first, second, third] = await history;
+
+        expect(first.getChildText("body")).toEqual("first message");
+        expect(first.attrs.from).toEqual(`${chatJid}/Alice`);
+        expect(second.getChildText("body")).toEqual("second message");
+        expect(second.attrs.from).toEqual(`${chatJid}/${bobNick}`);
+        expect(third.getChildText("body")).toEqual("third message");
+        expect(third.attrs.from).toEqual(`${chatJid}/Alice`);
+
+        for (const message of [first, second, third]) {
+            const stamp = message.getChild("delay", "urn:xmpp:delay")?.attrs.stamp;
+            expect(new Date(stamp).toString()).not.toEqual("Invalid Date");
+        }
+    });
+
+    test("does not replay history into a room whose history visibility isn't shared", async ({ testEnv, alice }) => {
+        const bobNick = "bob";
+        await alice.setDisplayName("Alice");
+        const alias = await createPublicRoom(testEnv, alice, "gateway-private-history-room", "Gateway Private History Room");
+        const roomId = await alice.resolveRoom(alias);
+        // Flip history_visibility before anyone joins over the gateway, so the very first
+        // GatewayHandler#getVirtualRoom hydration (uncached) picks it up as unsafe to replay.
+        await alice.sendStateEvent(roomId, "m.room.history_visibility", "", { history_visibility: "joined" });
+        const chatJid = roomJid(alias);
+        const joinTo = `${chatJid}/${bobNick}`;
+
+        await joinGateway(testEnv, joinTo);
+
+        const messageDelivered = waitForStanza(
+            testEnv.xmpp, "live message", (s) => s.is("message") && s.getChildText("body") === "should stay private",
+        );
+        await alice.sendMessage(roomId, { msgtype: "m.text", body: "should stay private" });
+        await messageDelivered;
+
+        await leaveGateway(testEnv, joinTo);
+
+        const history = collectStanzas(
+            testEnv.xmpp, "replayed history on rejoin (should not happen)", isDelayedGroupchatMessage, 1, 3000,
+        );
+        await joinGateway(testEnv, joinTo);
+        await expect(history).rejects.toThrow();
+    });
+});

--- a/spec/gateway-history.spec.ts
+++ b/spec/gateway-history.spec.ts
@@ -106,4 +106,53 @@ describe("XMPP gateway history backfill", () => {
         await joinGateway(testEnv, joinTo);
         await expect(history).rejects.toThrow();
     });
+
+    test("picks up a live history_visibility change without a restart, only caching what followed it", async ({ testEnv, alice }) => {
+        const bobNick = "bob";
+        await alice.setDisplayName("Alice");
+        const alias = await createPublicRoom(testEnv, alice, "gateway-history-visibility-change-room", "Gateway History Visibility Change Room");
+        const roomId = await alice.resolveRoom(alias);
+        // Restrict visibility before the gateway ever hydrates this room, so it starts out
+        // (correctly) treating history as unsafe to cache.
+        await alice.sendStateEvent(roomId, "m.room.history_visibility", "", { history_visibility: "joined" });
+        const chatJid = roomJid(alias);
+        const joinTo = `${chatJid}/${bobNick}`;
+
+        await joinGateway(testEnv, joinTo);
+
+        const beforeWideningDelivered = waitForStanza(
+            testEnv.xmpp, "live message before widening",
+            (s) => s.is("message") && s.getChildText("body") === "before widening",
+        );
+        await alice.sendMessage(roomId, { msgtype: "m.text", body: "before widening" });
+        await beforeWideningDelivered;
+
+        // Widen visibility with the gateway room already hydrated/cached - this only works if
+        // GatewayHandler#sendStateEvent live-patches the cached allowHistory flag rather than
+        // relying on a fresh (uncached) hydration to notice the change.
+        await alice.sendStateEvent(roomId, "m.room.history_visibility", "", { history_visibility: "shared" });
+
+        const afterWideningDelivered = waitForStanza(
+            testEnv.xmpp, "live message after widening",
+            (s) => s.is("message") && s.getChildText("body") === "after widening",
+        );
+        await alice.sendMessage(roomId, { msgtype: "m.text", body: "after widening" });
+        await afterWideningDelivered;
+
+        await leaveGateway(testEnv, joinTo);
+
+        // Only one message was ever eligible for caching - the one sent after visibility opened
+        // up. If the write side wasn't gated, "before widening" would show up here too.
+        const history = collectStanzas(
+            testEnv.xmpp, "replayed history on rejoin", isDelayedGroupchatMessage, 1,
+        );
+        await joinGateway(testEnv, joinTo);
+        const [onlyMessage] = await history;
+        expect(onlyMessage.getChildText("body")).toEqual("after widening");
+
+        const unexpectedSecondMessage = collectStanzas(
+            testEnv.xmpp, "a second replayed message (should not happen)", isDelayedGroupchatMessage, 1, 3000,
+        );
+        await expect(unexpectedSecondMessage).rejects.toThrow();
+    });
 });

--- a/spec/gateway-participation.spec.ts
+++ b/spec/gateway-participation.spec.ts
@@ -1,14 +1,13 @@
 import { describe, expect } from "vitest";
-import { xml, client as xmppClient } from "@xmpp/client";
-import { jid } from "@xmpp/jid";
-import type { Element } from "@xmpp/xml";
+import { xml } from "@xmpp/client";
 import { test as baseTest } from "./util/fixtures";
-import { XMPP_COMPONENT_DOMAIN, XMPP_C2S_DOMAIN, XMPP_TEST_USER } from "./util/containers/prosody";
+import { XMPP_C2S_DOMAIN, XMPP_TEST_USER } from "./util/containers/prosody";
 import { ghostMxidForXmppUser } from "./util/bifrost-env";
-import type { BifrostTestEnv, BifrostTestEnvOpts } from "./util/bifrost-env";
-import type { E2ETestMatrixClient } from "./util/e2e-test";
-
-const STANZA_WAIT_TIMEOUT = parseInt(process.env.BIFROST_TEST_WAIT_TIMEOUT ?? "20000", 10);
+import type { BifrostTestEnvOpts } from "./util/bifrost-env";
+import {
+    createPublicRoom, roomJid, waitForStanza, isPresenceFrom, hasMucStatusCode,
+    OccupantTracker, joinGateway,
+} from "./util/gateway";
 
 // Gateway room support only runs when portals.enableGateway is set - see XJSInstance#preStart.
 // Carol is a second Matrix user who joins a room and never leaves, purely so the membership
@@ -22,105 +21,6 @@ const test = baseTest.override("testEnvOpts", {
         portals: { enableGateway: true },
     },
 } as BifrostTestEnvOpts);
-
-async function createPublicRoom(
-    testEnv: BifrostTestEnv, alice: E2ETestMatrixClient, aliasLocalpart: string, name: string,
-): Promise<string> {
-    const roomId = await alice.createRoom({
-        visibility: "public",
-        preset: "public_chat",
-        name,
-        room_alias_name: aliasLocalpart,
-    });
-    const alias = `#${aliasLocalpart}:${testEnv.serverName}`;
-    // createRoom's room_alias_name maps the alias but does not set canonical_alias itself.
-    await alice.sendStateEvent(roomId, "m.room.canonical_alias", "", { alias });
-    return alias;
-}
-
-// Mirrors ServiceHandler#createJIDFromAlias, so tests can address a gateway room's JID directly.
-function roomJid(alias: string): string {
-    const [local, server] = alias.replace(/^#/, "").split(":");
-    return `#${local}#${server}@${XMPP_COMPONENT_DOMAIN}`;
-}
-
-function waitForStanza(
-    xmpp: ReturnType<typeof xmppClient>, description: string, predicate: (stanza: Element) => boolean,
-    timeoutMs = STANZA_WAIT_TIMEOUT,
-): Promise<Element> {
-    return new Promise((resolve, reject) => {
-        const onStanza = (stanza: Element) => {
-            if (predicate(stanza)) {
-                clearTimeout(timer);
-                xmpp.removeListener("stanza", onStanza);
-                resolve(stanza);
-            }
-        };
-        const timer = setTimeout(() => {
-            xmpp.removeListener("stanza", onStanza);
-            reject(new Error(`Timed out waiting for stanza: ${description}`));
-        }, timeoutMs);
-        xmpp.on("stanza", onStanza);
-    });
-}
-
-function isPresenceFrom(stanza: Element, from: string): boolean {
-    return stanza.is("presence") && stanza.attrs.from === from;
-}
-
-function hasMucStatusCode(stanza: Element, code: string): boolean {
-    return !!stanza.getChild("x", "http://jabber.org/protocol/muc#user")
-        ?.getChildren("status")
-        .some((s) => s.attrs.code === code);
-}
-
-/**
- * Tracks the occupants of a gateway room from incoming presence broadcasts, the way a real
- * XMPP client builds its member list - there's no disco#items support for the occupants of a
- * specific gateway room (only for listing rooms themselves), see ServiceHandler#handleIq.
- */
-class OccupantTracker {
-    private readonly nicks = new Set<string>();
-    private readonly handler = (stanza: Element) => {
-        if (!stanza.is("presence") || !stanza.attrs.from) {
-            return;
-        }
-        const from = jid(stanza.attrs.from);
-        if (!from.resource || `${from.local}@${from.domain}` !== this.chatJid) {
-            return;
-        }
-        if (stanza.attrs.type === "unavailable") {
-            this.nicks.delete(from.resource);
-        } else {
-            this.nicks.add(from.resource);
-        }
-    };
-
-    constructor(private xmpp: ReturnType<typeof xmppClient>, private chatJid: string) {
-        xmpp.on("stanza", this.handler);
-    }
-
-    public get occupantNicks(): string[] {
-        return [...this.nicks].sort();
-    }
-
-    public stop(): void {
-        this.xmpp.removeListener("stanza", this.handler);
-    }
-}
-
-/** Sends the MUC join presence used to enter a gateway room, and waits for the self-presence ack. */
-async function joinGateway(testEnv: BifrostTestEnv, joinTo: string): Promise<void> {
-    const selfPresence = waitForStanza(
-        testEnv.xmpp, "self-presence confirming gateway join",
-        (s) => isPresenceFrom(s, joinTo) && hasMucStatusCode(s, "110"),
-    );
-    await testEnv.xmpp.send(xml(
-        "presence", { to: joinTo },
-        xml("x", { xmlns: "http://jabber.org/protocol/muc" }),
-    ));
-    await selfPresence;
-}
 
 describe("XMPP gateway participation", () => {
     test("bridges bidirectional messages between a Matrix user and an XMPP user", async ({ testEnv, alice }) => {

--- a/spec/gateway-room-discovery.spec.ts
+++ b/spec/gateway-room-discovery.spec.ts
@@ -2,8 +2,8 @@ import { describe, expect } from "vitest";
 import { xml } from "@xmpp/client";
 import { test as baseTest } from "./util/fixtures";
 import { XMPP_COMPONENT_DOMAIN } from "./util/containers/prosody";
-import type { BifrostTestEnv, BifrostTestEnvOpts } from "./util/bifrost-env";
-import type { E2ETestMatrixClient } from "./util/e2e-test";
+import { createPublicRoom, roomJid } from "./util/gateway";
+import type { BifrostTestEnvOpts } from "./util/bifrost-env";
 
 // Gateway room discovery (ServiceHandler's disco#items/disco#info handling for gateway room
 // JIDs) only runs when portals.enableGateway is set - see XJSInstance#preStart.
@@ -12,27 +12,6 @@ const test = baseTest.override("testEnvOpts", {
         portals: { enableGateway: true },
     },
 } as BifrostTestEnvOpts);
-
-async function createPublicRoom(
-    testEnv: BifrostTestEnv, alice: E2ETestMatrixClient, aliasLocalpart: string, name: string,
-): Promise<string> {
-    const roomId = await alice.createRoom({
-        visibility: "public",
-        preset: "public_chat",
-        name,
-        room_alias_name: aliasLocalpart,
-    });
-    const alias = `#${aliasLocalpart}:${testEnv.serverName}`;
-    // createRoom's room_alias_name maps the alias but does not set canonical_alias itself.
-    await alice.sendStateEvent(roomId, "m.room.canonical_alias", "", { alias });
-    return alias;
-}
-
-// Mirrors ServiceHandler#createJIDFromAlias, so tests can address a gateway room's JID directly.
-function roomJid(alias: string): string {
-    const [local, server] = alias.replace(/^#/, "").split(":");
-    return `#${local}#${server}@${XMPP_COMPONENT_DOMAIN}`;
-}
 
 describe("XMPP gateway", () => {
     test("lists public Matrix rooms via disco#items", async ({ testEnv, alice }) => {

--- a/spec/util/gateway.ts
+++ b/spec/util/gateway.ts
@@ -1,0 +1,148 @@
+import { xml, client as xmppClient } from "@xmpp/client";
+import { jid } from "@xmpp/jid";
+import type { Element } from "@xmpp/xml";
+import { XMPP_COMPONENT_DOMAIN } from "./containers/prosody";
+import type { BifrostTestEnv } from "./bifrost-env";
+import type { E2ETestMatrixClient } from "./e2e-test";
+
+export const STANZA_WAIT_TIMEOUT = parseInt(process.env.BIFROST_TEST_WAIT_TIMEOUT ?? "20000", 10);
+
+export async function createPublicRoom(
+    testEnv: BifrostTestEnv, alice: E2ETestMatrixClient, aliasLocalpart: string, name: string,
+): Promise<string> {
+    const roomId = await alice.createRoom({
+        visibility: "public",
+        preset: "public_chat",
+        name,
+        room_alias_name: aliasLocalpart,
+    });
+    const alias = `#${aliasLocalpart}:${testEnv.serverName}`;
+    // createRoom's room_alias_name maps the alias but does not set canonical_alias itself.
+    await alice.sendStateEvent(roomId, "m.room.canonical_alias", "", { alias });
+    return alias;
+}
+
+// Mirrors ServiceHandler#createJIDFromAlias, so tests can address a gateway room's JID directly.
+export function roomJid(alias: string): string {
+    const [local, server] = alias.replace(/^#/, "").split(":");
+    return `#${local}#${server}@${XMPP_COMPONENT_DOMAIN}`;
+}
+
+export function waitForStanza(
+    xmpp: ReturnType<typeof xmppClient>, description: string, predicate: (stanza: Element) => boolean,
+    timeoutMs = STANZA_WAIT_TIMEOUT,
+): Promise<Element> {
+    return new Promise((resolve, reject) => {
+        const onStanza = (stanza: Element) => {
+            if (predicate(stanza)) {
+                clearTimeout(timer);
+                xmpp.removeListener("stanza", onStanza);
+                resolve(stanza);
+            }
+        };
+        const timer = setTimeout(() => {
+            xmpp.removeListener("stanza", onStanza);
+            reject(new Error(`Timed out waiting for stanza: ${description}`));
+        }, timeoutMs);
+        xmpp.on("stanza", onStanza);
+    });
+}
+
+/** Collects `count` matching stanzas, in arrival order. Rejects if that many don't show up in time. */
+export function collectStanzas(
+    xmpp: ReturnType<typeof xmppClient>, description: string, predicate: (stanza: Element) => boolean,
+    count: number, timeoutMs = STANZA_WAIT_TIMEOUT,
+): Promise<Element[]> {
+    return new Promise((resolve, reject) => {
+        const collected: Element[] = [];
+        const onStanza = (stanza: Element) => {
+            if (!predicate(stanza)) {
+                return;
+            }
+            collected.push(stanza);
+            if (collected.length >= count) {
+                clearTimeout(timer);
+                xmpp.removeListener("stanza", onStanza);
+                resolve(collected);
+            }
+        };
+        const timer = setTimeout(() => {
+            xmpp.removeListener("stanza", onStanza);
+            reject(new Error(`Timed out waiting for ${count} stanzas (got ${collected.length}): ${description}`));
+        }, timeoutMs);
+        xmpp.on("stanza", onStanza);
+    });
+}
+
+export function isPresenceFrom(stanza: Element, from: string): boolean {
+    return stanza.is("presence") && stanza.attrs.from === from;
+}
+
+export function hasMucStatusCode(stanza: Element, code: string): boolean {
+    return !!stanza.getChild("x", "http://jabber.org/protocol/muc#user")
+        ?.getChildren("status")
+        .some((s) => s.attrs.code === code);
+}
+
+export function isDelayedGroupchatMessage(stanza: Element): boolean {
+    return stanza.is("message") && stanza.attrs.type === "groupchat"
+        && !!stanza.getChild("delay", "urn:xmpp:delay");
+}
+
+/** Sends the MUC join presence used to enter a gateway room, and waits for the self-presence ack. */
+export async function joinGateway(testEnv: BifrostTestEnv, joinTo: string): Promise<void> {
+    const selfPresence = waitForStanza(
+        testEnv.xmpp, "self-presence confirming gateway join",
+        (s) => isPresenceFrom(s, joinTo) && hasMucStatusCode(s, "110"),
+    );
+    await testEnv.xmpp.send(xml(
+        "presence", { to: joinTo },
+        xml("x", { xmlns: "http://jabber.org/protocol/muc" }),
+    ));
+    await selfPresence;
+}
+
+/** Sends the MUC unavailable presence used to leave a gateway room, and waits for the self-presence ack. */
+export async function leaveGateway(testEnv: BifrostTestEnv, joinTo: string): Promise<void> {
+    const selfPresence = waitForStanza(
+        testEnv.xmpp, "self-presence confirming gateway leave",
+        (s) => isPresenceFrom(s, joinTo) && s.attrs.type === "unavailable" && hasMucStatusCode(s, "110"),
+    );
+    await testEnv.xmpp.send(xml("presence", { type: "unavailable", to: joinTo }));
+    await selfPresence;
+}
+
+/**
+ * Tracks the occupants of a gateway room from incoming presence broadcasts, the way a real
+ * XMPP client builds its member list - there's no disco#items support for the occupants of a
+ * specific gateway room (only for listing rooms themselves), see ServiceHandler#handleIq.
+ */
+export class OccupantTracker {
+    private readonly nicks = new Set<string>();
+    private readonly handler = (stanza: Element) => {
+        if (!stanza.is("presence") || !stanza.attrs.from) {
+            return;
+        }
+        const from = jid(stanza.attrs.from);
+        if (!from.resource || `${from.local}@${from.domain}` !== this.chatJid) {
+            return;
+        }
+        if (stanza.attrs.type === "unavailable") {
+            this.nicks.delete(from.resource);
+        } else {
+            this.nicks.add(from.resource);
+        }
+    };
+
+    constructor(private xmpp: ReturnType<typeof xmppClient>, private chatJid: string) {
+        xmpp.on("stanza", this.handler);
+    }
+
+    public get occupantNicks(): string[] {
+        return [...this.nicks].sort();
+    }
+
+    public stop(): void {
+        this.xmpp.removeListener("stanza", this.handler);
+    }
+}

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -143,6 +143,9 @@ export interface IConfigProfile {
 export interface IConfigPortals {
     aliases: {[regex: string]: IRoomAlias} | undefined;
     enableGateway: boolean;
+    // Maximum number of messages to retain per gateway room for history backfill on join.
+    // Kept small and in-memory by design - this is a courtesy backfill, not a durable log.
+    gatewayHistoryLimit?: number;
 }
 
 export interface IConfigProvisioning {

--- a/src/GatewayHandler.ts
+++ b/src/GatewayHandler.ts
@@ -14,6 +14,12 @@ const log = new Logger("GatewayHandler");
 
 const HISTORY_SAFE_ENUMS = ['shared', 'world_readable'];
 
+// Default to private: a room without a legible history_visibility value is treated the same
+// as "joined" (the most restrictive value XMPP joiners could still plausibly hit).
+function isHistoryVisibilitySafe(historyVisibility: unknown): boolean {
+    return HISTORY_SAFE_ENUMS.includes(typeof historyVisibility === "string" ? historyVisibility : "joined");
+}
+
 /**
  * Responsible for handling querys & events on behalf of a gateway style bridge.
  * The gateway system in the bridge is complex, so pull up a a pew and let's dig in.
@@ -75,12 +81,7 @@ export class GatewayHandler {
                 }
             ));
             const room: IGatewayRoom = {
-                // Default to private
-                allowHistory: HISTORY_SAFE_ENUMS.includes(
-                    typeof historyVis?.content?.history_visibility === "string"
-                        ? historyVis.content.history_visibility
-                        : "joined",
-                ),
+                allowHistory: isHistoryVisibilitySafe(historyVis?.content?.history_visibility),
                 name: typeof nameEv?.content?.name === "string" ? nameEv.content.name : "",
                 topic: typeof topicEv?.content?.topic === "string" ? topicEv.content.topic : "",
                 roomId,
@@ -128,6 +129,10 @@ export class GatewayHandler {
             log.info("Handing room avatar change for gateway");
             log.debug("Room avatar changes aren't supported yet.");
         //    this.purple.gateway.sendStateChange(chatName, sender, "topic", ev.content.topic);
+        } else if (ev.type === "m.room.history_visibility") {
+            log.info("Handling history visibility change for gateway");
+            room.allowHistory = isHistoryVisibilitySafe(ev.content?.history_visibility);
+            this.purple.gateway.setRoomHistoryAllowed(chatName, room.allowHistory);
         }
     }
 

--- a/src/GatewayHandler.ts
+++ b/src/GatewayHandler.ts
@@ -12,6 +12,8 @@ import { BifrostRemoteUser } from "./store/BifrostRemoteUser";
 
 const log = new Logger("GatewayHandler");
 
+const HISTORY_SAFE_ENUMS = ['shared', 'world_readable'];
+
 /**
  * Responsible for handling querys & events on behalf of a gateway style bridge.
  * The gateway system in the bridge is complex, so pull up a a pew and let's dig in.
@@ -61,6 +63,7 @@ export class GatewayHandler {
             log.debug(`Got state for ${roomId}`);
             const nameEv = state.find((e) => e.type === "m.room.name");
             const topicEv = state.find((e) => e.type === "m.room.topic");
+            const historyVis = state.find((e) => e.type === "m.room.history_visibility");
             const bot = this.bridge.getBot();
             const membership = state.filter((e) => e.type === "m.room.member").map((e: WeakEvent) => (
                 {
@@ -72,6 +75,12 @@ export class GatewayHandler {
                 }
             ));
             const room: IGatewayRoom = {
+                // Default to private
+                allowHistory: HISTORY_SAFE_ENUMS.includes(
+                    typeof historyVis?.content?.history_visibility === "string"
+                        ? historyVis.content.history_visibility
+                        : "joined",
+                ),
                 name: typeof nameEv?.content?.name === "string" ? nameEv.content.name : "",
                 topic: typeof topicEv?.content?.topic === "string" ? topicEv.content.topic : "",
                 roomId,

--- a/src/bifrost/Gateway.ts
+++ b/src/bifrost/Gateway.ts
@@ -31,6 +31,7 @@ export interface IGatewayRoom {
     topic: string;
     avatar?: string;
     roomId: string;
+    allowHistory: boolean;
     membership: {
         sender: string;
         stateKey: string;

--- a/src/bifrost/Gateway.ts
+++ b/src/bifrost/Gateway.ts
@@ -24,6 +24,12 @@ export interface IGateway extends IProfileProvider {
      * network (e.g. cached disco#info identities), so room lists pick the new name up live.
      */
     updateRoomName(roomId: string, name?: string): void;
+    /**
+     * The Matrix room's history_visibility changed: refresh whether messages arriving from the
+     * remote network are worth caching for backfill, so a tightened room doesn't keep building
+     * up a cache nobody will ever be allowed to read.
+     */
+    setRoomHistoryAllowed(chatName: string, allowed: boolean): void;
 }
 
 export interface IGatewayRoom {

--- a/src/xmppjs/HistoryManager.ts
+++ b/src/xmppjs/HistoryManager.ts
@@ -109,6 +109,7 @@ export class HistoryManager {
             for (; i > idx && numChars < limits.maxchars; i--) {
                 numChars += history[i - 1].toString().length;
             }
+            idx = i;
         }
 
         if (idx > 0) {

--- a/src/xmppjs/HistoryManager.ts
+++ b/src/xmppjs/HistoryManager.ts
@@ -1,0 +1,105 @@
+import { Element } from "@xmpp/xml";
+import { JID } from "@xmpp/jid";
+
+export interface IHistoryLimits {
+    maxChars?: number | undefined,
+    maxStanzas?: number | undefined,
+    seconds?: number | undefined,
+    since?: Date | undefined,
+}
+
+/**
+ * Abstraction of a history storage backend.
+ */
+interface IHistoryStorage {
+    // add a message to the history of a given room
+    addMessage: (chatName: string, message: Element, jid: JID) => Promise<void>;
+    // get the history of a room.  The storage should apply the limits that it
+    // wishes too, and remove the limits that it applied from the `limits`
+    // parameter.  The returned list of Elements must include the Delayed
+    // Delivery information.
+    getHistory: (chatName: string, limits: IHistoryLimits) => Promise<Element[]>;
+}
+
+// pad a number to be two digits long
+function pad2(n: number) {
+    return n < 10 ? "0" + n.toString() : n.toString();
+}
+
+/**
+ * Store room history in memory.
+ */
+export class MemoryStorage implements IHistoryStorage {
+    private history: Map<string, Element[]>;
+    constructor(public maxHistory: number) {
+        this.history = new Map();
+    }
+
+    async addMessage(chatName: string, message: Element, jid: JID): Promise<void> {
+        if (!this.history.has(chatName)) {
+            this.history.set(chatName, []);
+        }
+        const currRoomHistory = this.history.get(chatName);
+
+        // shallow-copy the message, and add the timestamp
+        const copiedMessage = new Element(message.name, message.attrs);
+        copiedMessage.append(message.children as Element[]);
+        copiedMessage.attr("from", jid.toString());
+        const now = new Date();
+        copiedMessage.append(new Element("delay", {
+            xmlns: "urn:xmpp:delay",
+            from: chatName,
+            // based on the polyfill at
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
+            stamp: now.getUTCFullYear() +
+                "-" + pad2(now.getUTCMonth() + 1) +
+                "-" + pad2(now.getUTCDate()) +
+                "T" + pad2(now.getUTCHours()) +
+                ":" + pad2(now.getUTCMinutes()) +
+                ":" + pad2(now.getUTCSeconds()) + "Z",
+        }));
+
+        currRoomHistory.push(copiedMessage);
+
+        while (currRoomHistory.length > this.maxHistory) {
+            currRoomHistory.shift();
+        }
+    }
+
+    async getHistory(chatName: string, limits: IHistoryLimits) {
+        return this.history.get(chatName) || [];
+    }
+}
+
+/**
+ * Manage room history for a MUC
+ */
+export class HistoryManager {
+    constructor(
+        private storage: IHistoryStorage,
+    ) {}
+
+    async addMessage(chatName: string, message: Element, jid: JID): Promise<void> {
+        console.log("adding message for room", chatName, message, jid);
+        return this.storage.addMessage(chatName, message, jid);
+    }
+
+    async getHistory(chatName: string, limits: IHistoryLimits): Promise<Element[]> {
+        console.log("getting messages for room", chatName);
+        if (limits.seconds) {
+            const since = new Date(Date.now() - limits.seconds * 1000);
+            if (limits.since === undefined || limits.since < since) {
+                limits.since = since;
+            }
+            delete limits.seconds;
+        }
+        let history: Element[] = await this.storage.getHistory(chatName, limits);
+
+        if ("maxStanzas" in limits && history.length > limits.maxStanzas) {
+            history = history.slice(-limits.maxStanzas);
+        }
+        // FIXME: filter by since, maxchars
+        console.log(history);
+        return history;
+    }
+}

--- a/src/xmppjs/HistoryManager.ts
+++ b/src/xmppjs/HistoryManager.ts
@@ -96,10 +96,10 @@ export class HistoryManager {
             for (; idx < history.length; idx++) {
                 try {
                     const ts = history[idx].getChild("delay", "urn:xmpp:delay")?.attr("stamp");
-                    if (new Date(Date.parse(ts)) >= limits.since) {
+                    if (new Date(ts) >= limits.since) {
                         break;
                     }
-                } catch (e) {}
+                } catch {}
             }
         }
 

--- a/src/xmppjs/HistoryManager.ts
+++ b/src/xmppjs/HistoryManager.ts
@@ -80,12 +80,10 @@ export class HistoryManager {
     ) {}
 
     async addMessage(chatName: string, message: Element, jid: JID): Promise<void> {
-        console.log("adding message for room", chatName, message, jid);
         return this.storage.addMessage(chatName, message, jid);
     }
 
     async getHistory(chatName: string, limits: IHistoryLimits): Promise<Element[]> {
-        console.log("getting messages for room", chatName);
         if (limits.seconds) {
             const since = new Date(Date.now() - limits.seconds * 1000);
             if (limits.since === undefined || limits.since < since) {
@@ -99,7 +97,6 @@ export class HistoryManager {
             history = history.slice(-limits.maxStanzas);
         }
         // FIXME: filter by since, maxchars
-        console.log(history);
         return history;
     }
 }

--- a/src/xmppjs/HistoryManager.ts
+++ b/src/xmppjs/HistoryManager.ts
@@ -65,11 +65,26 @@ export class MemoryStorage implements IHistoryStorage {
  * Manage room history for a MUC
  */
 export class HistoryManager {
+    // Rooms default to disallowed until told otherwise, so a room nobody has hydrated yet
+    // (or one caching gating hasn't been wired up for) never accumulates a cache it can't serve.
+    private allowedRooms = new Set<string>();
+
     constructor(
         private storage: IHistoryStorage,
     ) {}
 
+    setAllowed(chatName: string, allowed: boolean): void {
+        if (allowed) {
+            this.allowedRooms.add(chatName);
+        } else {
+            this.allowedRooms.delete(chatName);
+        }
+    }
+
     addMessage(chatName: string, message: Element, jid: JID): unknown {
+        if (!this.allowedRooms.has(chatName)) {
+            return;
+        }
         return this.storage.addMessage(chatName, message, jid);
     }
 

--- a/src/xmppjs/HistoryManager.ts
+++ b/src/xmppjs/HistoryManager.ts
@@ -99,7 +99,9 @@ export class HistoryManager {
                     if (new Date(ts) >= limits.since) {
                         break;
                     }
-                } catch {}
+                } catch {
+                    // Malformed delay stamp on a cached stanza - skip it and keep scanning.
+                }
             }
         }
 

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -52,10 +52,14 @@ export class XmppJsGateway implements IGateway {
         this.members = new GatewayMUCMembership();
         this.presenceCache = new PresenceCache(true);
         xmpp.on("received-chat-msg-xmpp", (convName: string, stanza: Element) => {
-            this.roomHistory.addMessage(
-                convName, stanza,
-                this.members.getXmppMemberByDevice(convName, stanza.attrs.from).anonymousJid,
-            );
+            try {
+                this.roomHistory.addMessage(
+                    convName, stanza,
+                    this.members.getXmppMemberByDevice(convName, stanza.attrs.from).anonymousJid,
+                );
+            } catch (ex) {
+                log.warn(`Failed to add message for ${convName} to history cache`);
+            }
         });
     }
 

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -28,6 +28,9 @@ import { IHistoryLimits, HistoryManager, MemoryStorage } from "./HistoryManager"
 
 const log = new Logger("XmppJsGateway");
 
+// A courtesy backfill, not a durable log - kept small and in-memory by design.
+const DEFAULT_HISTORY_LIMIT = 50;
+
 export interface RemoteGhostExtraData {
     rooms: {
         [chatName: string]: {devices: string[], jid: string}
@@ -46,8 +49,11 @@ export class XmppJsGateway implements IGateway {
     private presenceCache: PresenceCache;
     // Storing every XMPP user and their anonymous.
     private members: GatewayMUCMembership;
-    constructor(private xmpp: XmppJsInstance, private registration: AutoRegistration, private config: IConfigBridge) {
-        this.roomHistory = new HistoryManager(new MemoryStorage(50));
+    constructor(
+        private xmpp: XmppJsInstance, private registration: AutoRegistration, private config: IConfigBridge,
+        historyLimit: number = DEFAULT_HISTORY_LIMIT,
+    ) {
+        this.roomHistory = new HistoryManager(new MemoryStorage(historyLimit));
         this.stanzaCache = new Map();
         this.members = new GatewayMUCMembership();
         this.presenceCache = new PresenceCache(true);

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -456,7 +456,33 @@ export class XmppJsGateway implements IGateway {
         const historyLimits: IHistoryLimits = {};
         const historyRequest = stanza.getChild("x", "http://jabber.org/protocol/muc")?.getChild("history");
         if (historyRequest !== undefined) {
-            // FIXME: actually set limits
+            const getIntValue = (x) => {
+                if (!x.match(/^\d+$/)) {
+                    throw new Error("Not a number");
+                }
+                return parseInt(x);
+            };
+            const getDateValue = (x) => {
+                const val = Date.parse(x);
+                if (isNaN(val)) {
+                    throw new Error("Not a date");
+                }
+                return new Date(val); // Date.parse returns a number, which we need to turn into a Date object
+            };
+            const getHistoryParam = (name: string, parser: (string) => any): void => {
+                const param = historyRequest.getAttr(name);
+                if (param !== undefined) {
+                    try {
+                        historyLimits[name] = parser(param);
+                    } catch (e) {
+                        log.debug(`Invalid ${name} in history management: "${param}" (${e})`);
+                    }
+                }
+            };
+            getHistoryParam("maxchars", getIntValue);
+            getHistoryParam("maxstanzas", getIntValue);
+            getHistoryParam("seconds", getIntValue);
+            getHistoryParam("since", getDateValue);
         }
         const history: Element[] = await this.roomHistory.getHistory(chatName, historyLimits);
         history.forEach((e) => {

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -133,6 +133,10 @@ export class XmppJsGateway implements IGateway {
         this.xmpp.serviceHandler.updateCachedRoomName(roomId, name);
     }
 
+    public setRoomHistoryAllowed(chatName: string, allowed: boolean) {
+        this.roomHistory.setAllowed(chatName, allowed);
+    }
+
     public isJIDInMuc(chatName: string, j: JID) {
         return !!this.members.getXmppMemberByDevice(chatName, j);
     }
@@ -183,13 +187,13 @@ export class XmppJsGateway implements IGateway {
         );
 
         // add the message to the room history
-        const historyStanza = new StzaMessage(
-            from.anonymousJid.toString(),
-            "",
-            msg,
-            "groupchat",
-        );
         if (room.allowHistory) {
+            const historyStanza = new StzaMessage(
+                from.anonymousJid.toString(),
+                "",
+                msg,
+                "groupchat",
+            );
             this.roomHistory.addMessage(chatName, parse(historyStanza.xml), from.anonymousJid);
         }
 
@@ -233,8 +237,8 @@ export class XmppJsGateway implements IGateway {
         }
         stanza.attrs.from = preserveFrom;
         try {
-            // TODO: Currently we have no way to determine if this room has private history,
-            // so we may be adding more strain to the cache than nessacery.
+            // Silently a no-op if this room's history_visibility doesn't allow it - see
+            // HistoryManager#addMessage and IGateway#setRoomHistoryAllowed.
             this.roomHistory.addMessage(
                 chatName, stanza,
                 member.anonymousJid,
@@ -346,6 +350,10 @@ export class XmppJsGateway implements IGateway {
         if (!ownMxid) {
             throw Error('ownMxid is not defined');
         }
+
+        // Refresh this every join - it's cheap, and self-heals if a history_visibility change
+        // happened before setRoomHistoryAllowed's caller had a chance to tell us about it.
+        this.roomHistory.setAllowed(chatName, room.allowHistory);
 
         // Ensure our membership is accurate.
         this.updateMatrixMemberListForRoom(chatName, room, true); // HACK: Always update members for joiners

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -1,10 +1,17 @@
 import { XmppJsInstance, XMPP_PROTOCOL } from "./XJSInstance";
 import { Element, x } from "@xmpp/xml";
+import parse from "@xmpp/xml/lib/parse";
 import { jid, JID } from "@xmpp/jid";
 import { Logger } from "matrix-appservice-bridge";
 import { IConfigBridge } from "../Config";
 import { IBasicProtocolMessage } from "..//MessageFormatter";
-import { IGatewayJoin, IUserStateChanged, IStoreRemoteUser, IUserInfo } from "../bifrost/Events";
+import {
+    IGatewayJoin,
+    IUserStateChanged,
+    IStoreRemoteUser,
+    IUserInfo,
+    IReceivedImMsg
+} from "../bifrost/Events";
 import { IGatewayRoom } from "../bifrost/Gateway";
 import { PresenceCache } from "./PresenceCache";
 import { XHTMLIM } from "./XHTMLIM";
@@ -17,6 +24,7 @@ import { XMPPStatusCode } from "./XMPPConstants";
 import { AutoRegistration } from "../AutoRegistration";
 import { GatewayStateResolve } from "./GatewayStateResolve";
 import { MatrixMembershipEvent } from "../MatrixTypes";
+import { IHistoryLimits, HistoryManager, MemoryStorage } from "./HistoryManager";
 
 const log = new Logger("XmppJsGateway");
 
@@ -31,18 +39,24 @@ export interface RemoteGhostExtraData {
  * and XMPP.
  */
 export class XmppJsGateway implements IGateway {
-    // For storing room history, should be clipped at MAX_HISTORY per room.
-    private roomHistory: Map<string, [Element]>;
+    // For storing room history
+    private roomHistory: HistoryManager;
     // For storing requests to be responded to, like joins
     private stanzaCache: Map<string, Element>; // id -> stanza
     private presenceCache: PresenceCache;
     // Storing every XMPP user and their anonymous.
     private members: GatewayMUCMembership;
     constructor(private xmpp: XmppJsInstance, private registration: AutoRegistration, private config: IConfigBridge) {
-        this.roomHistory = new Map();
+        this.roomHistory = new HistoryManager(new MemoryStorage(50));
         this.stanzaCache = new Map();
         this.members = new GatewayMUCMembership();
         this.presenceCache = new PresenceCache(true);
+        xmpp.on("received-chat-msg-xmpp", (convName: string, stanza: Element) => {
+            this.roomHistory.addMessage(
+                convName, stanza,
+                this.members.getXmppMemberByDevice(convName, stanza.attrs.from).anonymousJid,
+            );
+        });
     }
 
     public handleStanza(stanza: Element, gatewayAlias: string) {
@@ -167,6 +181,16 @@ export class XmppJsGateway implements IGateway {
                 "groupchat",
             )
         );
+
+        // add the message to the room history
+        const historyStanza = new StzaMessage(
+            from.anonymousJid.toString(),
+            "",
+            msg,
+            "groupchat",
+        );
+        this.roomHistory.addMessage(chatName, parse(historyStanza.xml), from.anonymousJid);
+
         return this.xmpp.xmppSendBulk(msgs);
     }
 
@@ -429,10 +453,14 @@ export class XmppJsGateway implements IGateway {
 
         // 4. Room history
         log.debug("Emitting history");
-        const history: Element[] = this.roomHistory.get(room.roomId) || [];
+        const historyLimits: IHistoryLimits = {};
+        const historyRequest = stanza.getChild("x", "http://jabber.org/protocol/muc")?.getChild("history");
+        if (historyRequest !== undefined) {
+            console.log(historyRequest);
+        }
+        const history: Element[] = await this.roomHistory.getHistory(chatName, historyLimits);
         history.forEach((e) => {
             e.attrs.to = stanza.attrs.from;
-            // TODO: Add delay info to this.
             this.xmpp.xmppWriteToStream(e);
         });
 

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -456,7 +456,7 @@ export class XmppJsGateway implements IGateway {
         const historyLimits: IHistoryLimits = {};
         const historyRequest = stanza.getChild("x", "http://jabber.org/protocol/muc")?.getChild("history");
         if (historyRequest !== undefined) {
-            console.log(historyRequest);
+            // FIXME: actually set limits
         }
         const history: Element[] = await this.roomHistory.getHistory(chatName, historyLimits);
         history.forEach((e) => {

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -483,6 +483,9 @@ export class XmppJsGateway implements IGateway {
             getHistoryParam("maxstanzas", getIntValue);
             getHistoryParam("seconds", getIntValue);
             getHistoryParam("since", getDateValue);
+        } else {
+            // default to 20 stanzas if the client doesn't specify
+            historyLimits.maxstanzas = 20;
         }
         const history: Element[] = await this.roomHistory.getHistory(chatName, historyLimits);
         history.forEach((e) => {

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -464,7 +464,9 @@ export class XmppJsGateway implements IGateway {
             };
             const getDateValue = (str) => {
                 const val = new Date(str);
-                if (isNaN(val)) {
+                // TypeScript doesn't like giving a Date to isNaN, even though it
+                // works.  And it doesn't like converting directly to number.
+                if (isNaN(val as unknown as number)) {
                     throw new Error("Not a date");
                 }
                 return val;

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -456,20 +456,20 @@ export class XmppJsGateway implements IGateway {
         const historyLimits: IHistoryLimits = {};
         const historyRequest = stanza.getChild("x", "http://jabber.org/protocol/muc")?.getChild("history");
         if (historyRequest !== undefined) {
-            const getIntValue = (x) => {
-                if (!x.match(/^\d+$/)) {
+            const getIntValue = (str) => {
+                if (!str.match(/^\d+$/)) {
                     throw new Error("Not a number");
                 }
-                return parseInt(x);
+                return parseInt(str);
             };
-            const getDateValue = (x) => {
-                const val = Date.parse(x);
+            const getDateValue = (str) => {
+                const val = Date.parse(str);
                 if (isNaN(val)) {
                     throw new Error("Not a date");
                 }
                 return new Date(val); // Date.parse returns a number, which we need to turn into a Date object
             };
-            const getHistoryParam = (name: string, parser: (string) => any): void => {
+            const getHistoryParam = (name: string, parser: (str: string) => any): void => {
                 const param = historyRequest.getAttr(name);
                 if (param !== undefined) {
                     try {

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -467,7 +467,7 @@ export class XmppJsGateway implements IGateway {
                 if (isNaN(val)) {
                     throw new Error("Not a date");
                 }
-                return val; // Date.parse returns a number, which we need to turn into a Date object
+                return val;
             };
             const getHistoryParam = (name: string, parser: (str: string) => any): void => {
                 const param = historyRequest.getAttr(name);

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -457,17 +457,17 @@ export class XmppJsGateway implements IGateway {
         const historyRequest = stanza.getChild("x", "http://jabber.org/protocol/muc")?.getChild("history");
         if (historyRequest !== undefined) {
             const getIntValue = (str) => {
-                if (!str.match(/^\d+$/)) {
+                if (!/^\d+$/.test(str)) {
                     throw new Error("Not a number");
                 }
                 return parseInt(str);
             };
             const getDateValue = (str) => {
-                const val = Date.parse(str);
+                const val = new Date(str);
                 if (isNaN(val)) {
                     throw new Error("Not a date");
                 }
-                return new Date(val); // Date.parse returns a number, which we need to turn into a Date object
+                return val; // Date.parse returns a number, which we need to turn into a Date object
             };
             const getHistoryParam = (name: string, parser: (str: string) => any): void => {
                 const param = historyRequest.getAttr(name);

--- a/src/xmppjs/XJSGateway.ts
+++ b/src/xmppjs/XJSGateway.ts
@@ -51,16 +51,6 @@ export class XmppJsGateway implements IGateway {
         this.stanzaCache = new Map();
         this.members = new GatewayMUCMembership();
         this.presenceCache = new PresenceCache(true);
-        xmpp.on("received-chat-msg-xmpp", (convName: string, stanza: Element) => {
-            try {
-                this.roomHistory.addMessage(
-                    convName, stanza,
-                    this.members.getXmppMemberByDevice(convName, stanza.attrs.from).anonymousJid,
-                );
-            } catch (ex) {
-                log.warn(`Failed to add message for ${convName} to history cache`);
-            }
-        });
     }
 
     public handleStanza(stanza: Element, gatewayAlias: string) {
@@ -193,7 +183,9 @@ export class XmppJsGateway implements IGateway {
             msg,
             "groupchat",
         );
-        this.roomHistory.addMessage(chatName, parse(historyStanza.xml), from.anonymousJid);
+        if (room.allowHistory) {
+            this.roomHistory.addMessage(chatName, parse(historyStanza.xml), from.anonymousJid);
+        }
 
         return this.xmpp.xmppSendBulk(msgs);
     }
@@ -234,6 +226,16 @@ export class XmppJsGateway implements IGateway {
             return false;
         }
         stanza.attrs.from = preserveFrom;
+        try {
+            // TODO: Currently we have no way to determine if this room has private history,
+            // so we may be adding more strain to the cache than nessacery.
+            this.roomHistory.addMessage(
+                chatName, stanza,
+                member.anonymousJid,
+            );
+        } catch (ex) {
+            log.warn(`Failed to add message for ${chatName} to history cache`);
+        }
         return true;
     }
 
@@ -456,48 +458,52 @@ export class XmppJsGateway implements IGateway {
         );
 
         // 4. Room history
-        log.debug("Emitting history");
-        const historyLimits: IHistoryLimits = {};
-        const historyRequest = stanza.getChild("x", "http://jabber.org/protocol/muc")?.getChild("history");
-        if (historyRequest !== undefined) {
-            const getIntValue = (str) => {
-                if (!/^\d+$/.test(str)) {
-                    throw new Error("Not a number");
-                }
-                return parseInt(str);
-            };
-            const getDateValue = (str) => {
-                const val = new Date(str);
-                // TypeScript doesn't like giving a Date to isNaN, even though it
-                // works.  And it doesn't like converting directly to number.
-                if (isNaN(val as unknown as number)) {
-                    throw new Error("Not a date");
-                }
-                return val;
-            };
-            const getHistoryParam = (name: string, parser: (str: string) => any): void => {
-                const param = historyRequest.getAttr(name);
-                if (param !== undefined) {
-                    try {
-                        historyLimits[name] = parser(param);
-                    } catch (e) {
-                        log.debug(`Invalid ${name} in history management: "${param}" (${e})`);
+        if (room.allowHistory) {
+            log.debug("Emitting history");
+            const historyLimits: IHistoryLimits = {};
+            const historyRequest = stanza.getChild("x", "http://jabber.org/protocol/muc")?.getChild("history");
+            if (historyRequest !== undefined) {
+                const getIntValue = (str) => {
+                    if (!/^\d+$/.test(str)) {
+                        throw new Error("Not a number");
                     }
-                }
-            };
-            getHistoryParam("maxchars", getIntValue);
-            getHistoryParam("maxstanzas", getIntValue);
-            getHistoryParam("seconds", getIntValue);
-            getHistoryParam("since", getDateValue);
+                    return parseInt(str);
+                };
+                const getDateValue = (str) => {
+                    const val = new Date(str);
+                    // TypeScript doesn't like giving a Date to isNaN, even though it
+                    // works.  And it doesn't like converting directly to number.
+                    if (isNaN(val as unknown as number)) {
+                        throw new Error("Not a date");
+                    }
+                    return val;
+                };
+                const getHistoryParam = (name: string, parser: (str: string) => any): void => {
+                    const param = historyRequest.getAttr(name);
+                    if (param !== undefined) {
+                        try {
+                            historyLimits[name] = parser(param);
+                        } catch (e) {
+                            log.debug(`Invalid ${name} in history management: "${param}" (${e})`);
+                        }
+                    }
+                };
+                getHistoryParam("maxchars", getIntValue);
+                getHistoryParam("maxstanzas", getIntValue);
+                getHistoryParam("seconds", getIntValue);
+                getHistoryParam("since", getDateValue);
+            } else {
+                // default to 20 stanzas if the client doesn't specify
+                historyLimits.maxstanzas = 20;
+            }
+            const history: Element[] = await this.roomHistory.getHistory(chatName, historyLimits);
+            history.forEach((e) => {
+                e.attrs.to = stanza.attrs.from;
+                this.xmpp.xmppWriteToStream(e);
+            });
         } else {
-            // default to 20 stanzas if the client doesn't specify
-            historyLimits.maxstanzas = 20;
+            log.debug("Not emitting history, room does not have visibility turned on");
         }
-        const history: Element[] = await this.roomHistory.getHistory(chatName, historyLimits);
-        history.forEach((e) => {
-            e.attrs.to = stanza.attrs.from;
-            this.xmpp.xmppWriteToStream(e);
-        });
 
         log.debug("Emitting subject");
         // 5. The room subject

--- a/src/xmppjs/XJSInstance.ts
+++ b/src/xmppjs/XJSInstance.ts
@@ -144,7 +144,9 @@ export class XmppJsInstance extends EventEmitter implements IBifrostInstance {
             if (!this.autoRegister) {
                 throw Error("Autoregistration must be enabled for gateways to work!");
             }
-            this.xmppGateway = new XmppJsGateway(this, this.autoRegister, this.config.bridge);
+            this.xmppGateway = new XmppJsGateway(
+                this, this.autoRegister, this.config.bridge, this.config.portals.gatewayHistoryLimit,
+            );
         }
     }
 

--- a/src/xmppjs/XJSInstance.ts
+++ b/src/xmppjs/XJSInstance.ts
@@ -646,7 +646,6 @@ export class XmppJsInstance extends EventEmitter implements IBifrostInstance {
                     log.warn(`Message could not be sent, not forwarding to Matrix`);
                     return;
                 }
-                this.emit("received-chat-msg-xmpp", convName, stanza);
                 // We deliberately do not anonymize the JID here.
                 // We do however strip the resource
                 from = jid(`${from.local}@${from.domain}`);

--- a/src/xmppjs/XJSInstance.ts
+++ b/src/xmppjs/XJSInstance.ts
@@ -646,6 +646,7 @@ export class XmppJsInstance extends EventEmitter implements IBifrostInstance {
                     log.warn(`Message could not be sent, not forwarding to Matrix`);
                     return;
                 }
+                this.emit("received-chat-msg-xmpp", convName, stanza);
                 // We deliberately do not anonymize the JID here.
                 // We do however strip the resource
                 from = jid(`${from.local}@${from.domain}`);
@@ -841,7 +842,6 @@ export class XmppJsInstance extends EventEmitter implements IBifrostInstance {
 
         if (type === "groupchat") {
             log.debug("Emitting group message", message);
-            this.emit("received-chat-msg-xmpp", convName, stanza);
             this.emit("received-chat-msg", {
                 eventName: "received-chat-msg",
                 sender: from.toString(),

--- a/src/xmppjs/XJSInstance.ts
+++ b/src/xmppjs/XJSInstance.ts
@@ -841,6 +841,7 @@ export class XmppJsInstance extends EventEmitter implements IBifrostInstance {
 
         if (type === "groupchat") {
             log.debug("Emitting group message", message);
+            this.emit("received-chat-msg-xmpp", convName, stanza);
             this.emit("received-chat-msg", {
                 eventName: "received-chat-msg",
                 sender: from.toString(),

--- a/test/xmppjs/test_HistoryManager.ts
+++ b/test/xmppjs/test_HistoryManager.ts
@@ -1,0 +1,49 @@
+import { expect } from "chai";
+import { MemoryStorage, HistoryManager } from "../../src/xmppjs/HistoryManager";
+import { Element } from "@xmpp/xml";
+import { JID } from "@xmpp/jid";
+
+describe("HistoryManager", () => {
+    describe("MemoryStorage", () => {
+        it("should return filtered history", async () => {
+            const historyManager = new HistoryManager(new MemoryStorage(20));
+            historyManager.addMessage(
+                "room1@example.org", new Element("stanza1"),
+                new JID("room1", "example.org", "user1"),
+            );
+            historyManager.addMessage(
+                "room1@example.org", new Element("stanza2"),
+                new JID("room1", "example.org", "user1"),
+            );
+            historyManager.addMessage(
+                "room1@example.org", new Element("stanza3"),
+                new JID("room1", "example.org", "user1"),
+            );
+            historyManager.addMessage(
+                "room2@example.org", new Element("stanza1"),
+                new JID("room1", "example.org", "user1"),
+            );
+
+            const unfilteredRoom1 = await historyManager.getHistory("room1@example.org", {});
+            expect(unfilteredRoom1.length).to.equal(3);
+            const unfilteredRoom2 = await historyManager.getHistory("room2@example.org", {});
+            expect(unfilteredRoom2.length).to.equal(1);
+
+            const maxStanzasRoom1 = await historyManager.getHistory("room1@example.org", {
+                maxstanzas: 2,
+            });
+            expect(maxStanzasRoom1.length).to.equal(2);
+            const maxStanzasRoom2 = await historyManager.getHistory("room2@example.org", {
+                maxstanzas: 2,
+            });
+            expect(maxStanzasRoom2.length).to.equal(1);
+
+            // each stanza will be about 40 characters, so maxchars 50 should
+            // only give us one stanza
+            const maxCharsRoom1 = await historyManager.getHistory("room1@example.org", {
+                maxchars: 50,
+            });
+            expect(maxCharsRoom1.length).to.equal(1);
+        });
+    });
+});

--- a/test/xmppjs/test_HistoryManager.ts
+++ b/test/xmppjs/test_HistoryManager.ts
@@ -7,6 +7,8 @@ describe("HistoryManager", () => {
     describe("MemoryStorage", () => {
         it("should return filtered history", async () => {
             const historyManager = new HistoryManager(new MemoryStorage(20));
+            historyManager.setAllowed("room1@example.org", true);
+            historyManager.setAllowed("room2@example.org", true);
             historyManager.addMessage(
                 "room1@example.org", new Element("stanza1"),
                 new JID("room1", "example.org", "user1"),
@@ -44,6 +46,33 @@ describe("HistoryManager", () => {
                 maxchars: 50,
             });
             expect(maxCharsRoom1.length).to.equal(1);
+        });
+
+        it("should not cache messages for a room that has not been allowed", async () => {
+            const historyManager = new HistoryManager(new MemoryStorage(20));
+            historyManager.addMessage(
+                "room1@example.org", new Element("stanza1"),
+                new JID("room1", "example.org", "user1"),
+            );
+
+            expect(await historyManager.getHistory("room1@example.org", {})).to.have.lengthOf(0);
+        });
+
+        it("should stop caching messages once a room is disallowed", async () => {
+            const historyManager = new HistoryManager(new MemoryStorage(20));
+            historyManager.setAllowed("room1@example.org", true);
+            historyManager.addMessage(
+                "room1@example.org", new Element("stanza1"),
+                new JID("room1", "example.org", "user1"),
+            );
+
+            historyManager.setAllowed("room1@example.org", false);
+            historyManager.addMessage(
+                "room1@example.org", new Element("stanza2"),
+                new JID("room1", "example.org", "user1"),
+            );
+
+            expect(await historyManager.getHistory("room1@example.org", {})).to.have.lengthOf(1);
         });
     });
 });

--- a/test/xmppjs/test_XJSGateway.ts
+++ b/test/xmppjs/test_XJSGateway.ts
@@ -75,6 +75,7 @@ describe("XJSGateway", () => {
                 topic: "GatewayTopic",
                 roomId: "!foo:bar",
                 membership: [],
+                allowHistory: true,
             };
             try {
                 await gw.onRemoteJoin(null, "myjoinid", room, "@_xmpp_foo:bar");
@@ -95,6 +96,7 @@ describe("XJSGateway", () => {
                     createMember("@_xmpp_baz:bar", "Baz"),
                     createMember("@leavy:bar", "Leavy", "leave"),
                 ],
+                allowHistory: true,
             };
             gw.handleStanza(
                 x("presence", {
@@ -156,6 +158,7 @@ describe("XJSGateway", () => {
                     createMember("@_xmpp_baz:bar", "Baz"),
                     createMember("@leavy:bar", "Leavy", "leave"),
                 ],
+                allowHistory: true,
             };
             gw.handleStanza(
                 x("presence", {
@@ -184,6 +187,7 @@ describe("XJSGateway", () => {
                 topic: "GatewayTopic",
                 roomId: "!foo:bar",
                 membership,
+                allowHistory: true,
             };
             gw.handleStanza(
                 x("presence", {
@@ -208,6 +212,7 @@ describe("XJSGateway", () => {
                 topic: "GatewayTopic",
                 roomId: "!foo:bar",
                 membership: [],
+                allowHistory: true,
             };
             gw.handleStanza(
                 x("presence", {


### PR DESCRIPTION
Replaces #227 

Allows gateway mode to replay history to new joiners to a MUC